### PR TITLE
Port POC into AirTable PBGL atp tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+AIRTABLE_API_TOKEN=your_token_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Python-generated files
+__pycache__/
+*.py[oc]
+build/
+dist/
+wheels/
+*.egg-info
+
+# Virtual environments
+.venv
+
+# Secrets
+.env
+
+# Large source HTML (re-download from Airtable when needed)
+DOCS/AIRTABLE_API/*.html
+
+# Test coverage
+.coverage
+htmlcov/
+
+# macOS
+.DS_Store

--- a/DOCS/AIRTABLE_API/apm-dist-mgmt.md
+++ b/DOCS/AIRTABLE_API/apm-dist-mgmt.md
@@ -1,0 +1,221 @@
+# APM Dist Mgmt
+
+**Table ID:** `tbllGX2Hxg3SGhJMa`  
+**Base ID:** `appEurfA8kXQE3slK`
+
+---
+
+## Fields
+
+| Field Name                         | Field ID            | Type                   | Description                                                                      |
+| ---------------------------------- | ------------------- | ---------------------- | -------------------------------------------------------------------------------- |
+| Track Title                        | `fldw6XoYUYYWMGLr6` | Text                   | A single line of text.                                                           |
+| Submission Status                  | `fld5G5W7HhiCncJJL` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| CD ID                              | `fldKwsNdbf12KbLJ8` | Text                   | A single line of text.                                                           |
+| ISRC (from Recording)              | `fldLEkwvdPr6lmv0T` | Lookup                 | Array of ISRC fields in linked Recordings records.                               |
+| ISWC                               | `fldYunRRdpQC3l0zd` | Lookup                 | Array of ISWC (from Compositions) fields in linked Recordings records.           |
+| Date Submitted                     | `fldZnRtxfeiOgBekS` | Date                   | UTC date, e.g. "2014-09-05".                                                     |
+| From Release                       | `fldJNJzhWluDYWDTS` | Link to another record | Array of linked records IDs from the Releases table.                             |
+| Recording                          | `fldHwS1bgXbIMxljd` | Link to another record | Array of linked records IDs from the Recordings table.                           |
+| Notes                              | `fldQbOWgt0Z0KFD5N` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| APM Submission Spreadsheet         | `fldNl4XkUw4djAaJt` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| Track Number                       | `fldAYGYUgYGhzdkGa` | Text                   | A single line of text.                                                           |
+| Label                              | `fldEJLnJXVFpt5eKe` | Text                   | A single line of text.                                                           |
+| Library ID                         | `fldMxBobhfU94zG8c` | Text                   | A single line of text.                                                           |
+| Primary Artist (from CD Title)     | `fld7GBEdOrATDvKDK` | Lookup                 | Array of Primary Artist fields in linked Recordings records.                     |
+| Featured Artist(s) (from CD Title) | `fldJHVnAq3DueyaZy` | Lookup                 | Array of Featured Artist(s) fields in linked Releases records.                   |
+| Duration (from Recording)          | `fldWfqRUI1xYlf6fF` | Lookup                 | Array of Duration fields in linked Recordings records.                           |
+| UPC (from From Release)            | `fldFGKuFIjtJ35dro` | Lookup                 | Array of UPC fields in linked Releases records.                                  |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/apm%20dist%20mgmt`
+
+To list records in APM Dist Mgmt , issue a GET request to the APM Dist Mgmt endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Returned records do not include any fields with "empty" values, e.g. "" , [] , or false .
+
+```bash
+curl "https://api.airtable.com/v0/appEurfA8kXQE3slK/APM%20Dist%20Mgmt?maxRecords=3&view=Grid%20view" \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+### Query Parameters
+
+| Parameter               | Type             | Required   | Description                                                                      |
+| ----------------------- | ---------------- | ---------- | -------------------------------------------------------------------------------- |
+| `fields`                | array of strings | optional   | Only data for fields whose names are in this list will be included in the result. If you don't need every field, you can use this parameter to reduce the amount of data transferred. For example, to only return data from Track Title and Submission Status , send these two query parameters: fields%5B%5 |
+| `filterByFormula`       | string           | optional   | A formula used to filter records. The formula will be evaluated for each record, and if the result is not 0 , false , "" , NaN , [] , or #Error! the record will be included in the response. We recommend testing your formula in the Formula field UI before using it in your API request. If combined wit |
+| `maxRecords`            | number           | optional   | The maximum total number of records that will be returned in your requests. If this value is larger than pageSize (which is 100 by default), you may have to load multiple pages to reach this total. See the Pagination section below for more. |
+| `pageSize`              | number           | optional   | The number of records returned in each request. Must be less than or equal to 100. Default is 100. See the Pagination section below for more. |
+| `sort`                  | array of objects | optional   | A list of sort objects that specifies how the records will be ordered. Each sort object must have a field key specifying the name of the field to sort on, and an optional direction key that is either "asc" or "desc" . The default direction is "asc" . The sort parameter overrides the sorting of the v |
+| `view`                  | string           | optional   | The name or ID of a view in the APM Dist Mgmt table. If set, only the records in that view will be returned. The records will be sorted according to the order of the view unless the sort parameter is included, which overrides that order. Fields hidden in this view will be returned in the results. To |
+| `cellFormat`            | string           | optional   | The format that should be used for cell values. Supported values are: json : cells will be formatted as JSON, depending on the field type. string : cells will be formatted as user-facing strings, regardless of the field type. The timeZone and userLocale parameters are required when using string as t |
+| `timeZone`              | string           | optional   | The time zone that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `userLocale`            | string           | optional   | The user locale that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `returnFieldsByFieldId` | boolean          | optional   | An optional boolean value that lets you return field objects where the key is the field id. This defaults to false , which returns field objects where the key is the field name. |
+| `recordMetadata`        | array of strings | optional   | An optional field that, if includes commentCount , adds a commentCount read only property on each record returned. |
+
+---
+
+## Retrieve a Record
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/apm%20dist%20mgmt`
+
+To retrieve an existing record in APM Dist Mgmt table, issue a GET request to the record endpoint.
+
+Any "empty" fields (e.g. "" , [] , or false ) in the record will not be returned.
+
+```bash
+curl https://api.airtable.com/v0/appEurfA8kXQE3slK/APM%20Dist%20Mgmt/rec3tq2hwx8hoUkfk \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+---
+
+## Create Records
+
+**Endpoint:** `POST /v0/appEurfA8kXQE3slK/apm%20dist%20mgmt`
+
+To create new records, issue a POST request to the APM Dist Mgmt endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have one key whose value is an inner object containing your record's cell values, keyed by either field name or field id.
+
+```bash
+curl -X POST https://api.airtable.com/v0/appEurfA8kXQE3slK/APM%20Dist%20Mgmt \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "fields": {
+        "Track Title": "Love Fever",
+        "Submission Status": "Done",
+        "CD ID": "APMC-0267 Love Fever",
+        "Date Submitted": "2025-05-07",
+        "From Release": [
+          "recXsooBINci69iNL"
+        ],
+        "Recording": [
+          "recuvy6EBHKGez45Q"
+        ],
+        "APM Submission Spreadsheet": "https://docs.google.com/spreadsheets/d/1NDyQxqTIt_ET2jVEYhlMIz79Oxk0Rq9U/edit?gid=1859837858#gid=1859837858\n",
+        "Track Number": "1",
+        "Library ID": "APM"
+      }
+    },
+    {
+      "fields": {
+        "Track Title": "We Would Fall In Love",
+        "Submission Status": "Done",
+        "CD ID": "APMC-0268 Hopeless Romantic",
+        "Date Submitted": "2025-05-16",
+        "From Release": [
+          "recYPdn9oppMGYoWZ"
+        ],
+        "Recording": [
+          "recBd4KUsyEbH5Mwp"
+        ],
+        "APM Submission Spreadsheet": "https://docs.google.com/spreadsheets/d/1i4OCBN9V32ow2KXh7UpeUX7g9dtJpGDg/edit?gid=1859837858#gid=1859837858",
+        "Track Number": "1",
+        "Library ID": "APM"
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Update / Upsert Records
+
+**Endpoint:** `PATCH /v0/appEurfA8kXQE3slK/apm%20dist%20mgmt`
+
+To update APM Dist Mgmt records, issue a request to the APM Dist Mgmt endpoint. Table names and table IDs can be used interchangeably. Using table IDs means table name changes won't require modifying your API request code. A PATCH request will only update the fields included in the request. Fields not included in the request will be unchanged. A PUT request will perform a destructive update and clear all unincluded cell values.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have an id property representing the record ID and a fields property which contains all of your record's cell values by field name or field id for all of your record's cell values by field name.
+
+```bash
+curl -X PATCH https://api.airtable.com/v0/appEurfA8kXQE3slK/APM%20Dist%20Mgmt \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "id": "rec3tq2hwx8hoUkfk",
+      "fields": {
+        "Track Title": "Love Fever",
+        "Submission Status": "Done",
+        "CD ID": "APMC-0267 Love Fever",
+        "Date Submitted": "2025-05-07",
+        "From Release": [
+          "recXsooBINci69iNL"
+        ],
+        "Recording": [
+          "recuvy6EBHKGez45Q"
+        ],
+        "APM Submission Spreadsheet": "https://docs.google.com/spreadsheets/d/1NDyQxqTIt_ET2jVEYhlMIz79Oxk0Rq9U/edit?gid=1859837858#gid=1859837858\n",
+        "Track Number": "1",
+        "Library ID": "APM"
+      }
+    },
+    {
+      "id": "recPgmjdD9HiNftar",
+      "fields": {
+        "Track Title": "We Would Fall In Love",
+        "Submission Status": "Done",
+        "CD ID": "APMC-0268 Hopeless Romantic",
+        "Date Submitted": "2025-05-16",
+        "From Release": [
+          "recYPdn9oppMGYoWZ"
+        ],
+        "Recording": [
+          "recBd4KUsyEbH5Mwp"
+        ],
+        "APM Submission Spreadsheet": "https://docs.google.com/spreadsheets/d/1i4OCBN9V32ow2KXh7UpeUX7g9dtJpGDg/edit?gid=1859837858#gid=1859837858",
+        "Track Number": "1",
+        "Library ID": "APM"
+      }
+    },
+    {
+      "id": "recAvwjx4zfiB3ukY",
+      "fields": {
+        "Track Title": "I Saw Santa Prayin'\''",
+        "Submission Status": "Done",
+        "CD ID": "APMC-0270 The True Spirit of Christmas",
+        "Date Submitted": "2025-06-03",
+        "From Release": [
+          "recIHFCTKTZOCs7U6"
+        ],
+        "Recording": [
+          "recZR4dmKscLFWFnZ"
+        ],
+        "APM Submission Spreadsheet": "https://docs.google.com/spreadsheets/d/1u-zbEz8smZoVw31eHufKOgYsQvgP_aGj/edit?gid=1859837858#gid=1859837858",
+        "Track Number": "1",
+        "Library ID": "APM"
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Delete Records
+
+**Endpoint:** `DELETE /v0/appEurfA8kXQE3slK/apm%20dist%20mgmt`
+
+To delete APM Dist Mgmt records, issue a DELETE request to the APM Dist Mgmt endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request should include a URL-encoded array of up to 10 record IDs to delete.
+
+```bash
+curl -X DELETE https://api.airtable.com/v0/appEurfA8kXQE3slK/APM%20Dist%20Mgmt \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -G \
+  --data-urlencode 'records[]=rec3tq2hwx8hoUkfk' \
+  --data-urlencode 'records[]=recPgmjdD9HiNftar'
+```
+

--- a/DOCS/AIRTABLE_API/artists.md
+++ b/DOCS/AIRTABLE_API/artists.md
@@ -1,0 +1,215 @@
+# Artists
+
+**Table ID:** `tbla7zxpHm76x0Aj9`  
+**Base ID:** `appEurfA8kXQE3slK`
+
+---
+
+## Fields
+
+| Field Name                     | Field ID            | Type                   | Description                                                                      |
+| ------------------------------ | ------------------- | ---------------------- | -------------------------------------------------------------------------------- |
+| Name                           | `fldF4ZWQAGe4rmDOA` | Formula                | Computed value: { Artist First Name } & " " & { Artist Last Name/Band Name } .   |
+| Notes                          | `fldS4kuMTIm2bX5XW` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| Artist First Name              | `fld0MOqw1LTw7uPV8` | Text                   | A single line of text.                                                           |
+| Artist Last Name/Band Name     | `fldhbPXA2b0LMVf2m` | Text                   | A single line of text.                                                           |
+| Primary Recordings             | `fld9Eyowsg94qVrJe` | Link to another record | Array of linked records IDs from the Recordings table.                           |
+| Featured Recordings            | `flddCYswYDG3kkOY8` | Link to another record | Array of linked records IDs from the Recordings table.                           |
+| Primary Releases               | `fldMZrQCVME3cIBnE` | Link to another record | Array of linked records IDs from the Releases table. Because this field is configured to show records in reversed order, the order of records in the app will be reversed compared to what you see here. |
+| Featured Releases              | `fldXrX9pcvBTDf7YF` | Link to another record | Array of linked records IDs from the Releases table. Because this field is configured to show records in reversed order, the order of records in the app will be reversed compared to what you see here. |
+| APM Dist Mgmt                  | `fldWZBcn8HIdOwZnc` | Text                   | A single line of text.                                                           |
+| Legal Docs                     | `fldnpu57KRbN8DIAg` | Link to another record | Array of linked records IDs from the Legal Docs table.                           |
+| Spotify Artist ID              | `fldY7faosSIy0HAIs` | Text                   | A single line of text.                                                           |
+| Listed On GoldLabelArtists.com | `fld972ZFSPcmWJbDs` | Checkbox               | This field is "true" when checked and otherwise empty.                           |
+| Spotify Artist URL             | `fld7OktIOmK4YZQWL` | URL                    | A valid URL (e.g. airtable.com or https://airtable.com/universe).                |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/artists`
+
+To list records in Artists , issue a GET request to the Artists endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Returned records do not include any fields with "empty" values, e.g. "" , [] , or false .
+
+```bash
+curl "https://api.airtable.com/v0/appEurfA8kXQE3slK/Artists?maxRecords=3&view=Default" \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+### Query Parameters
+
+| Parameter               | Type             | Required   | Description                                                                      |
+| ----------------------- | ---------------- | ---------- | -------------------------------------------------------------------------------- |
+| `fields`                | array of strings | optional   | Only data for fields whose names are in this list will be included in the result. If you don't need every field, you can use this parameter to reduce the amount of data transferred. For example, to only return data from Name and Notes , send these two query parameters: fields%5B%5D=Name&fields%5B%5D |
+| `filterByFormula`       | string           | optional   | A formula used to filter records. The formula will be evaluated for each record, and if the result is not 0 , false , "" , NaN , [] , or #Error! the record will be included in the response. We recommend testing your formula in the Formula field UI before using it in your API request. If combined wit |
+| `maxRecords`            | number           | optional   | The maximum total number of records that will be returned in your requests. If this value is larger than pageSize (which is 100 by default), you may have to load multiple pages to reach this total. See the Pagination section below for more. |
+| `pageSize`              | number           | optional   | The number of records returned in each request. Must be less than or equal to 100. Default is 100. See the Pagination section below for more. |
+| `sort`                  | array of objects | optional   | A list of sort objects that specifies how the records will be ordered. Each sort object must have a field key specifying the name of the field to sort on, and an optional direction key that is either "asc" or "desc" . The default direction is "asc" . The sort parameter overrides the sorting of the v |
+| `view`                  | string           | optional   | The name or ID of a view in the Artists table. If set, only the records in that view will be returned. The records will be sorted according to the order of the view unless the sort parameter is included, which overrides that order. Fields hidden in this view will be returned in the results. To only |
+| `cellFormat`            | string           | optional   | The format that should be used for cell values. Supported values are: json : cells will be formatted as JSON, depending on the field type. string : cells will be formatted as user-facing strings, regardless of the field type. The timeZone and userLocale parameters are required when using string as t |
+| `timeZone`              | string           | optional   | The time zone that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `userLocale`            | string           | optional   | The user locale that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `returnFieldsByFieldId` | boolean          | optional   | An optional boolean value that lets you return field objects where the key is the field id. This defaults to false , which returns field objects where the key is the field name. |
+| `recordMetadata`        | array of strings | optional   | An optional field that, if includes commentCount , adds a commentCount read only property on each record returned. |
+
+---
+
+## Retrieve a Record
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/artists`
+
+To retrieve an existing record in Artists table, issue a GET request to the record endpoint.
+
+Any "empty" fields (e.g. "" , [] , or false ) in the record will not be returned.
+
+```bash
+curl https://api.airtable.com/v0/appEurfA8kXQE3slK/Artists/recIp9KshxzJgCfH8 \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+---
+
+## Create Records
+
+**Endpoint:** `POST /v0/appEurfA8kXQE3slK/artists`
+
+To create new records, issue a POST request to the Artists endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have one key whose value is an inner object containing your record's cell values, keyed by either field name or field id.
+
+```bash
+curl -X POST https://api.airtable.com/v0/appEurfA8kXQE3slK/Artists \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "fields": {
+        "Artist Last Name/Band Name": "2nd Chapter Of Acts",
+        "Primary Recordings": [
+          "rectH1q4KEoCmsyjv",
+          "recx5ETAQxSdakUWq"
+        ],
+        "Primary Releases": [
+          "recQQ7zqlKb6ojPYk"
+        ]
+      }
+    },
+    {
+      "fields": {
+        "Artist Last Name/Band Name": "Abilene Christian College A Cappella Chorus",
+        "Primary Recordings": [
+          "recRlYpxC4hl4SjoM",
+          "recCzHyEO9vDHggWa",
+          "reciPOjHKVNZtNjVo",
+          "recYa0DvsABggA5ax",
+          "rec5ebFo785QJlGXg",
+          "recU25AWTYRQYlfUa",
+          "recbfVg1HJEcbDFWL",
+          "rec3qFXbsK8QlbHyE",
+          "recoDtUOjPKbdvyse",
+          "recWv655B9CMaOBGE",
+          "recztMbyFD6Gv5KZq",
+          "recA3tVjuaE1LrRjd"
+        ],
+        "Primary Releases": [
+          "reckg4ihxipgfLwaG"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Update / Upsert Records
+
+**Endpoint:** `PATCH /v0/appEurfA8kXQE3slK/artists`
+
+To update Artists records, issue a request to the Artists endpoint. Table names and table IDs can be used interchangeably. Using table IDs means table name changes won't require modifying your API request code. A PATCH request will only update the fields included in the request. Fields not included in the request will be unchanged. A PUT request will perform a destructive update and clear all unincluded cell values.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have an id property representing the record ID and a fields property which contains all of your record's cell values by field name or field id for all of your record's cell values by field name.
+
+```bash
+curl -X PATCH https://api.airtable.com/v0/appEurfA8kXQE3slK/Artists \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "id": "recIp9KshxzJgCfH8",
+      "fields": {
+        "Artist Last Name/Band Name": "2nd Chapter Of Acts",
+        "Primary Recordings": [
+          "rectH1q4KEoCmsyjv",
+          "recx5ETAQxSdakUWq"
+        ],
+        "Primary Releases": [
+          "recQQ7zqlKb6ojPYk"
+        ]
+      }
+    },
+    {
+      "id": "reczifaRa5S5vyCn4",
+      "fields": {
+        "Artist Last Name/Band Name": "Abilene Christian College A Cappella Chorus",
+        "Primary Recordings": [
+          "recRlYpxC4hl4SjoM",
+          "recCzHyEO9vDHggWa",
+          "reciPOjHKVNZtNjVo",
+          "recYa0DvsABggA5ax",
+          "rec5ebFo785QJlGXg",
+          "recU25AWTYRQYlfUa",
+          "recbfVg1HJEcbDFWL",
+          "rec3qFXbsK8QlbHyE",
+          "recoDtUOjPKbdvyse",
+          "recWv655B9CMaOBGE",
+          "recztMbyFD6Gv5KZq",
+          "recA3tVjuaE1LrRjd"
+        ],
+        "Primary Releases": [
+          "reckg4ihxipgfLwaG"
+        ]
+      }
+    },
+    {
+      "id": "recz4zL6zUK5awktL",
+      "fields": {
+        "Notes": "https://open.spotify.com/artist/6rJqqRce0Kvo2dJUXoHleC?si=SjlgX7-OTMagDfdPKThE6Q",
+        "Artist Last Name/Band Name": "Alabama",
+        "Featured Recordings": [
+          "recxd50ETB5ZD1QCI",
+          "rec9EUc5YvTbDEajJ"
+        ],
+        "Featured Releases": [
+          "recYTUWpVF0ZXSuLR",
+          "rec0z6GYgSbJOOBHM",
+          "recOnTdJxvaTVQmpY"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Delete Records
+
+**Endpoint:** `DELETE /v0/appEurfA8kXQE3slK/artists`
+
+To delete Artists records, issue a DELETE request to the Artists endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request should include a URL-encoded array of up to 10 record IDs to delete.
+
+```bash
+curl -X DELETE https://api.airtable.com/v0/appEurfA8kXQE3slK/Artists \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -G \
+  --data-urlencode 'records[]=recIp9KshxzJgCfH8' \
+  --data-urlencode 'records[]=reczifaRa5S5vyCn4'
+```
+

--- a/DOCS/AIRTABLE_API/artists_copy.md
+++ b/DOCS/AIRTABLE_API/artists_copy.md
@@ -1,0 +1,215 @@
+# Artists
+
+**Table ID:** `tbla7zxpHm76x0Aj9`  
+**Base ID:** `appEurfA8kXQE3slK`
+
+---
+
+## Fields
+
+| Field Name                     | Field ID            | Type                   | Description                                                                      |
+| ------------------------------ | ------------------- | ---------------------- | -------------------------------------------------------------------------------- |
+| Name                           | `fldF4ZWQAGe4rmDOA` | Formula                | Computed value: { Artist First Name } & " " & { Artist Last Name/Band Name } .   |
+| Notes                          | `fldS4kuMTIm2bX5XW` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| Artist First Name              | `fld0MOqw1LTw7uPV8` | Text                   | A single line of text.                                                           |
+| Artist Last Name/Band Name     | `fldhbPXA2b0LMVf2m` | Text                   | A single line of text.                                                           |
+| Primary Recordings             | `fld9Eyowsg94qVrJe` | Link to another record | Array of linked records IDs from the Recordings table.                           |
+| Featured Recordings            | `flddCYswYDG3kkOY8` | Link to another record | Array of linked records IDs from the Recordings table.                           |
+| Primary Releases               | `fldMZrQCVME3cIBnE` | Link to another record | Array of linked records IDs from the Releases table. Because this field is configured to show records in reversed order, the order of records in the app will be reversed compared to what you see here. |
+| Featured Releases              | `fldXrX9pcvBTDf7YF` | Link to another record | Array of linked records IDs from the Releases table. Because this field is configured to show records in reversed order, the order of records in the app will be reversed compared to what you see here. |
+| APM Dist Mgmt                  | `fldWZBcn8HIdOwZnc` | Text                   | A single line of text.                                                           |
+| Legal Docs                     | `fldnpu57KRbN8DIAg` | Link to another record | Array of linked records IDs from the Legal Docs table.                           |
+| Spotify Artist ID              | `fldY7faosSIy0HAIs` | Text                   | A single line of text.                                                           |
+| Listed On GoldLabelArtists.com | `fld972ZFSPcmWJbDs` | Checkbox               | This field is "true" when checked and otherwise empty.                           |
+| Spotify Artist URL             | `fld7OktIOmK4YZQWL` | URL                    | A valid URL (e.g. airtable.com or https://airtable.com/universe).                |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/artists`
+
+To list records in Artists , issue a GET request to the Artists endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Returned records do not include any fields with "empty" values, e.g. "" , [] , or false .
+
+```bash
+curl "https://api.airtable.com/v0/appEurfA8kXQE3slK/Artists?maxRecords=3&view=Default" \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+### Query Parameters
+
+| Parameter               | Type             | Required   | Description                                                                      |
+| ----------------------- | ---------------- | ---------- | -------------------------------------------------------------------------------- |
+| `fields`                | array of strings | optional   | Only data for fields whose names are in this list will be included in the result. If you don't need every field, you can use this parameter to reduce the amount of data transferred. For example, to only return data from Name and Notes , send these two query parameters: fields%5B%5D=Name&fields%5B%5D |
+| `filterByFormula`       | string           | optional   | A formula used to filter records. The formula will be evaluated for each record, and if the result is not 0 , false , "" , NaN , [] , or #Error! the record will be included in the response. We recommend testing your formula in the Formula field UI before using it in your API request. If combined wit |
+| `maxRecords`            | number           | optional   | The maximum total number of records that will be returned in your requests. If this value is larger than pageSize (which is 100 by default), you may have to load multiple pages to reach this total. See the Pagination section below for more. |
+| `pageSize`              | number           | optional   | The number of records returned in each request. Must be less than or equal to 100. Default is 100. See the Pagination section below for more. |
+| `sort`                  | array of objects | optional   | A list of sort objects that specifies how the records will be ordered. Each sort object must have a field key specifying the name of the field to sort on, and an optional direction key that is either "asc" or "desc" . The default direction is "asc" . The sort parameter overrides the sorting of the v |
+| `view`                  | string           | optional   | The name or ID of a view in the Artists table. If set, only the records in that view will be returned. The records will be sorted according to the order of the view unless the sort parameter is included, which overrides that order. Fields hidden in this view will be returned in the results. To only |
+| `cellFormat`            | string           | optional   | The format that should be used for cell values. Supported values are: json : cells will be formatted as JSON, depending on the field type. string : cells will be formatted as user-facing strings, regardless of the field type. The timeZone and userLocale parameters are required when using string as t |
+| `timeZone`              | string           | optional   | The time zone that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `userLocale`            | string           | optional   | The user locale that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `returnFieldsByFieldId` | boolean          | optional   | An optional boolean value that lets you return field objects where the key is the field id. This defaults to false , which returns field objects where the key is the field name. |
+| `recordMetadata`        | array of strings | optional   | An optional field that, if includes commentCount , adds a commentCount read only property on each record returned. |
+
+---
+
+## Retrieve a Record
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/artists`
+
+To retrieve an existing record in Artists table, issue a GET request to the record endpoint.
+
+Any "empty" fields (e.g. "" , [] , or false ) in the record will not be returned.
+
+```bash
+curl https://api.airtable.com/v0/appEurfA8kXQE3slK/Artists/recIp9KshxzJgCfH8 \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+---
+
+## Create Records
+
+**Endpoint:** `POST /v0/appEurfA8kXQE3slK/artists`
+
+To create new records, issue a POST request to the Artists endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have one key whose value is an inner object containing your record's cell values, keyed by either field name or field id.
+
+```bash
+curl -X POST https://api.airtable.com/v0/appEurfA8kXQE3slK/Artists \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "fields": {
+        "Artist Last Name/Band Name": "2nd Chapter Of Acts",
+        "Primary Recordings": [
+          "rectH1q4KEoCmsyjv",
+          "recx5ETAQxSdakUWq"
+        ],
+        "Primary Releases": [
+          "recQQ7zqlKb6ojPYk"
+        ]
+      }
+    },
+    {
+      "fields": {
+        "Artist Last Name/Band Name": "Abilene Christian College A Cappella Chorus",
+        "Primary Recordings": [
+          "recRlYpxC4hl4SjoM",
+          "recCzHyEO9vDHggWa",
+          "reciPOjHKVNZtNjVo",
+          "recYa0DvsABggA5ax",
+          "rec5ebFo785QJlGXg",
+          "recU25AWTYRQYlfUa",
+          "recbfVg1HJEcbDFWL",
+          "rec3qFXbsK8QlbHyE",
+          "recoDtUOjPKbdvyse",
+          "recWv655B9CMaOBGE",
+          "recztMbyFD6Gv5KZq",
+          "recA3tVjuaE1LrRjd"
+        ],
+        "Primary Releases": [
+          "reckg4ihxipgfLwaG"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Update / Upsert Records
+
+**Endpoint:** `PATCH /v0/appEurfA8kXQE3slK/artists`
+
+To update Artists records, issue a request to the Artists endpoint. Table names and table IDs can be used interchangeably. Using table IDs means table name changes won't require modifying your API request code. A PATCH request will only update the fields included in the request. Fields not included in the request will be unchanged. A PUT request will perform a destructive update and clear all unincluded cell values.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have an id property representing the record ID and a fields property which contains all of your record's cell values by field name or field id for all of your record's cell values by field name.
+
+```bash
+curl -X PATCH https://api.airtable.com/v0/appEurfA8kXQE3slK/Artists \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "id": "recIp9KshxzJgCfH8",
+      "fields": {
+        "Artist Last Name/Band Name": "2nd Chapter Of Acts",
+        "Primary Recordings": [
+          "rectH1q4KEoCmsyjv",
+          "recx5ETAQxSdakUWq"
+        ],
+        "Primary Releases": [
+          "recQQ7zqlKb6ojPYk"
+        ]
+      }
+    },
+    {
+      "id": "reczifaRa5S5vyCn4",
+      "fields": {
+        "Artist Last Name/Band Name": "Abilene Christian College A Cappella Chorus",
+        "Primary Recordings": [
+          "recRlYpxC4hl4SjoM",
+          "recCzHyEO9vDHggWa",
+          "reciPOjHKVNZtNjVo",
+          "recYa0DvsABggA5ax",
+          "rec5ebFo785QJlGXg",
+          "recU25AWTYRQYlfUa",
+          "recbfVg1HJEcbDFWL",
+          "rec3qFXbsK8QlbHyE",
+          "recoDtUOjPKbdvyse",
+          "recWv655B9CMaOBGE",
+          "recztMbyFD6Gv5KZq",
+          "recA3tVjuaE1LrRjd"
+        ],
+        "Primary Releases": [
+          "reckg4ihxipgfLwaG"
+        ]
+      }
+    },
+    {
+      "id": "recz4zL6zUK5awktL",
+      "fields": {
+        "Notes": "https://open.spotify.com/artist/6rJqqRce0Kvo2dJUXoHleC?si=SjlgX7-OTMagDfdPKThE6Q",
+        "Artist Last Name/Band Name": "Alabama",
+        "Featured Recordings": [
+          "recxd50ETB5ZD1QCI",
+          "rec9EUc5YvTbDEajJ"
+        ],
+        "Featured Releases": [
+          "recYTUWpVF0ZXSuLR",
+          "rec0z6GYgSbJOOBHM",
+          "recOnTdJxvaTVQmpY"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Delete Records
+
+**Endpoint:** `DELETE /v0/appEurfA8kXQE3slK/artists`
+
+To delete Artists records, issue a DELETE request to the Artists endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request should include a URL-encoded array of up to 10 record IDs to delete.
+
+```bash
+curl -X DELETE https://api.airtable.com/v0/appEurfA8kXQE3slK/Artists \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -G \
+  --data-urlencode 'records[]=recIp9KshxzJgCfH8' \
+  --data-urlencode 'records[]=reczifaRa5S5vyCn4'
+```
+

--- a/DOCS/AIRTABLE_API/chevy-showroom-dist-mgmt.md
+++ b/DOCS/AIRTABLE_API/chevy-showroom-dist-mgmt.md
@@ -1,0 +1,228 @@
+# Chevy Showroom Dist Mgmt
+
+**Table ID:** `tblRqFtQrPCNB1fwT`  
+**Base ID:** `appEurfA8kXQE3slK`
+
+---
+
+## Fields
+
+| Field Name               | Field ID            | Type                   | Description                                                                      |
+| ------------------------ | ------------------- | ---------------------- | -------------------------------------------------------------------------------- |
+| Recording Title          | `fldZhsS8bGm4LGxLS` | Text                   | A single line of text.                                                           |
+| Release                  | `fld8ZRGggXaSZ6WPr` | Link to another record | Array of linked records IDs from the Releases table.                             |
+| Notes                    | `fld7kLLkIUiPmfy3M` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| Episode #                | `fldTzZVVUDpCBYhDo` | Text                   | A single line of text.                                                           |
+| Album Release Title      | `fldvNBJ8rLb8uUpNL` | Text                   | A single line of text.                                                           |
+| Title Version            | `fldCbkW2mpolcnYle` | Text                   | A single line of text.                                                           |
+| Featured Artist          | `fld3VHweZjXKPe63e` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Date First Aired         | `fldjweCFBABr72S1n` | Date                   | UTC date, e.g. "2014-09-05".                                                     |
+| Release Date             | `fldVKtAmpmdL9v2WY` | Date                   | UTC date, e.g. "2014-09-05".                                                     |
+| UPC                      | `fldeuaXpQVlO1OxDS` | Barcode                | The barcode object may contain the following two properties, both of which are optional. text string barcode data type string barcode symbology, e.g. "upce" or "code39" |
+| PRODUCT CODE             | `fldJOnZr2BOyT3Ebb` | Barcode                | The barcode object may contain the following two properties, both of which are optional. text string barcode data type string barcode symbology, e.g. "upce" or "code39" |
+| ISRC                     | `fldyfDCWl8w5uVcFb` | Text                   | A single line of text.                                                           |
+| ISWC                     | `fldEQ1iIkvxelBnsQ` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| Orchard                  | `fldGjZniYnGwZ3CSl` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Apple                    | `fld2uyYBypJOWceJc` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Recordings               | `fldu3zfcd8SW7QJwG` | Link to another record | Array of linked records IDs from the Recordings table.                           |
+| Verified Publishing Info | `fldzdRFrDKCSuUmqo` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| DISCO                    | `fldwb0wYhqCfmzA09` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/chevy%20showroom%20dist%20mgmt`
+
+To list records in Chevy Showroom Dist Mgmt , issue a GET request to the Chevy Showroom Dist Mgmt endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Returned records do not include any fields with "empty" values, e.g. "" , [] , or false .
+
+```bash
+curl "https://api.airtable.com/v0/appEurfA8kXQE3slK/Chevy%20Showroom%20Dist%20Mgmt?maxRecords=3&view=Grid%20view" \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+### Query Parameters
+
+| Parameter               | Type             | Required   | Description                                                                      |
+| ----------------------- | ---------------- | ---------- | -------------------------------------------------------------------------------- |
+| `fields`                | array of strings | optional   | Only data for fields whose names are in this list will be included in the result. If you don't need every field, you can use this parameter to reduce the amount of data transferred. For example, to only return data from Recording Title and Release , send these two query parameters: fields%5B%5D=Reco |
+| `filterByFormula`       | string           | optional   | A formula used to filter records. The formula will be evaluated for each record, and if the result is not 0 , false , "" , NaN , [] , or #Error! the record will be included in the response. We recommend testing your formula in the Formula field UI before using it in your API request. If combined wit |
+| `maxRecords`            | number           | optional   | The maximum total number of records that will be returned in your requests. If this value is larger than pageSize (which is 100 by default), you may have to load multiple pages to reach this total. See the Pagination section below for more. |
+| `pageSize`              | number           | optional   | The number of records returned in each request. Must be less than or equal to 100. Default is 100. See the Pagination section below for more. |
+| `sort`                  | array of objects | optional   | A list of sort objects that specifies how the records will be ordered. Each sort object must have a field key specifying the name of the field to sort on, and an optional direction key that is either "asc" or "desc" . The default direction is "asc" . The sort parameter overrides the sorting of the v |
+| `view`                  | string           | optional   | The name or ID of a view in the Chevy Showroom Dist Mgmt table. If set, only the records in that view will be returned. The records will be sorted according to the order of the view unless the sort parameter is included, which overrides that order. Fields hidden in this view will be returned in the |
+| `cellFormat`            | string           | optional   | The format that should be used for cell values. Supported values are: json : cells will be formatted as JSON, depending on the field type. string : cells will be formatted as user-facing strings, regardless of the field type. The timeZone and userLocale parameters are required when using string as t |
+| `timeZone`              | string           | optional   | The time zone that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `userLocale`            | string           | optional   | The user locale that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `returnFieldsByFieldId` | boolean          | optional   | An optional boolean value that lets you return field objects where the key is the field id. This defaults to false , which returns field objects where the key is the field name. |
+| `recordMetadata`        | array of strings | optional   | An optional field that, if includes commentCount , adds a commentCount read only property on each record returned. |
+
+---
+
+## Retrieve a Record
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/chevy%20showroom%20dist%20mgmt`
+
+To retrieve an existing record in Chevy Showroom Dist Mgmt table, issue a GET request to the record endpoint.
+
+Any "empty" fields (e.g. "" , [] , or false ) in the record will not be returned.
+
+```bash
+curl https://api.airtable.com/v0/appEurfA8kXQE3slK/Chevy%20Showroom%20Dist%20Mgmt/recFDfo8UviaFKyvZ \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+---
+
+## Create Records
+
+**Endpoint:** `POST /v0/appEurfA8kXQE3slK/chevy%20showroom%20dist%20mgmt`
+
+To create new records, issue a POST request to the Chevy Showroom Dist Mgmt endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have one key whose value is an inner object containing your record's cell values, keyed by either field name or field id.
+
+```bash
+curl -X POST https://api.airtable.com/v0/appEurfA8kXQE3slK/Chevy%20Showroom%20Dist%20Mgmt \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "fields": {
+        "Recording Title": "Santa Claus Is Coming To Town",
+        "Notes": "Not Released ",
+        "Episode #": "10",
+        "Album Release Title": "Santa Claus Is Coming To Town (Live On The Pat Boone Chevy Showroom, December 5, 1957)",
+        "Title Version": "Live On The Pat Boone Chevy Showroom, December 5, 1957",
+        "Date First Aired": "1957-12-05",
+        "ISWC": "T0701341458",
+        "Recordings": [
+          "recwaCl6e4EfWDeUv"
+        ]
+      }
+    },
+    {
+      "fields": {
+        "Recording Title": "Lost In The Stars ",
+        "Episode #": "30",
+        "Album Release Title": "Lost In The Stars (Live On The Pat Boone Chevy Showroom, May 5, 1958)",
+        "Title Version": "Live On The Pat Boone Chevy Showroom, May 5, 1958",
+        "Date First Aired": "1958-05-01",
+        "UPC": {
+          "text": "786052581055"
+        },
+        "PRODUCT CODE": {
+          "text": "GLDA581055"
+        },
+        "ISRC": "QT27V2500155",
+        "Orchard": [
+          "Lyric Sheet Edited"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Update / Upsert Records
+
+**Endpoint:** `PATCH /v0/appEurfA8kXQE3slK/chevy%20showroom%20dist%20mgmt`
+
+To update Chevy Showroom Dist Mgmt records, issue a request to the Chevy Showroom Dist Mgmt endpoint. Table names and table IDs can be used interchangeably. Using table IDs means table name changes won't require modifying your API request code. A PATCH request will only update the fields included in the request. Fields not included in the request will be unchanged. A PUT request will perform a destructive update and clear all unincluded cell values.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have an id property representing the record ID and a fields property which contains all of your record's cell values by field name or field id for all of your record's cell values by field name.
+
+```bash
+curl -X PATCH https://api.airtable.com/v0/appEurfA8kXQE3slK/Chevy%20Showroom%20Dist%20Mgmt \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "id": "recFDfo8UviaFKyvZ",
+      "fields": {
+        "Recording Title": "Santa Claus Is Coming To Town",
+        "Notes": "Not Released ",
+        "Episode #": "10",
+        "Album Release Title": "Santa Claus Is Coming To Town (Live On The Pat Boone Chevy Showroom, December 5, 1957)",
+        "Title Version": "Live On The Pat Boone Chevy Showroom, December 5, 1957",
+        "Date First Aired": "1957-12-05",
+        "ISWC": "T0701341458",
+        "Recordings": [
+          "recwaCl6e4EfWDeUv"
+        ]
+      }
+    },
+    {
+      "id": "recEc9cxPn8LdEjUi",
+      "fields": {
+        "Recording Title": "Lost In The Stars ",
+        "Episode #": "30",
+        "Album Release Title": "Lost In The Stars (Live On The Pat Boone Chevy Showroom, May 5, 1958)",
+        "Title Version": "Live On The Pat Boone Chevy Showroom, May 5, 1958",
+        "Date First Aired": "1958-05-01",
+        "UPC": {
+          "text": "786052581055"
+        },
+        "PRODUCT CODE": {
+          "text": "GLDA581055"
+        },
+        "ISRC": "QT27V2500155",
+        "Orchard": [
+          "Lyric Sheet Edited"
+        ]
+      }
+    },
+    {
+      "id": "recEpp5RtZlJf9NU7",
+      "fields": {
+        "Recording Title": "Too Young",
+        "Release": [
+          "recc2xkqF3CIwyYpm"
+        ],
+        "Episode #": "28",
+        "Album Release Title": "Too Young (Live On The Pat Boone Chevy Showroom, April 10, 1958)",
+        "Title Version": "Live On The Pat Boone Chevy Showroom, April 10, 1958",
+        "Date First Aired": "1958-04-10",
+        "UPC": {
+          "text": "786052580942"
+        },
+        "PRODUCT CODE": {
+          "text": "GLDA580942"
+        },
+        "ISRC": "QT27V2500144",
+        "Orchard": [
+          "Lyric Sheet Edited"
+        ],
+        "Recordings": [
+          "rechYjEXKEkxRMHat"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Delete Records
+
+**Endpoint:** `DELETE /v0/appEurfA8kXQE3slK/chevy%20showroom%20dist%20mgmt`
+
+To delete Chevy Showroom Dist Mgmt records, issue a DELETE request to the Chevy Showroom Dist Mgmt endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request should include a URL-encoded array of up to 10 record IDs to delete.
+
+```bash
+curl -X DELETE https://api.airtable.com/v0/appEurfA8kXQE3slK/Chevy%20Showroom%20Dist%20Mgmt \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -G \
+  --data-urlencode 'records[]=recFDfo8UviaFKyvZ' \
+  --data-urlencode 'records[]=recEc9cxPn8LdEjUi'
+```
+

--- a/DOCS/AIRTABLE_API/compositions.md
+++ b/DOCS/AIRTABLE_API/compositions.md
@@ -1,0 +1,509 @@
+# Compositions
+
+**Table ID:** `tblomWINKPjfgAVpo`  
+**Base ID:** `appEurfA8kXQE3slK`
+
+---
+
+## Fields
+
+| Field Name                                                      | Field ID            | Type                   | Description                                                                      |
+| --------------------------------------------------------------- | ------------------- | ---------------------- | -------------------------------------------------------------------------------- |
+| Song Title In PRO                                               | `fldBLBpVsd3kBKapM` | Text                   | A single line of text.                                                           |
+| Notes                                                           | `fld0D3S3I77KWWIMM` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| REGISTRATION PROJECT                                            | `fldN5elY1M8qIXXZ4` | Link to another record | Array of linked records IDs from the REGISTRATION PROJECT (PRO +MLC) table.      |
+| ISWC                                                            | `fldVv5OnnDxzqcmIA` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| MLC Song Code                                                   | `fld2WmSMkPTGWOhVh` | Text                   | A single line of text.                                                           |
+| MLC work links                                                  | `fldPHd0XjNLVAbzmW` | URL                    | A valid URL (e.g. airtable.com or https://airtable.com/universe).                |
+| Recordings                                                      | `fldVjjMa9H9Zpx9p0` | Link to another record | Array of linked records IDs from the Recordings table.                           |
+| Duration (from Recordings)                                      | `fldOOnejpImbNJ2l2` | Lookup                 | Array of Duration fields in linked Recordings records.                           |
+| Verified Info                                                   | `fldzjgPgUAGkkE6fy` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| PRO Registration Status                                         | `fldfOZcMxH4OLCMiU` | Lookup                 | Array of PROs fields in linked REGISTRATION PROJECT (PRO +MLC) records.          |
+| MLC Registration Status                                         | `fldH7AnLMPfiJDcV9` | Lookup                 | Array of fields in linked REGISTRATION PROJECT (PRO +MLC) records.               |
+| Ready for Sync                                                  | `fldExx4NthXNGImyi` | Lookup                 | Array of Ready for Sync fields in linked Recordings records.                     |
+| All Songwriters                                                 | `fldRfWFbfjTZXzfKP` | Link to another record | Array of linked records IDs from the Songwriters table.                          |
+| IPI Number (from All Songwriters)                               | `fldI1DzNcShZI3raL` | Lookup                 | Array of IPI Number fields in linked Songwriters records.                        |
+| All Original Publishers                                         | `fldkIOo7kToJaT5zm` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Recording Title                                                 | `fldGwLne6e5FZzn1Q` | Lookup                 | Array of Title of Recording fields in linked Recordings records.                 |
+| Alternate Title                                                 | `fld2z6RCiksnybQZC` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| Primary Artist (from Recordings)                                | `fldbeWmTOAt5r9kBI` | Lookup                 | Array of Primary Artist fields in linked Recordings records.                     |
+| ISRC (from Recordings)                                          | `fldK3wvMstiKhS9Gm` | Lookup                 | Array of ISRC fields in linked Recordings records.                               |
+| Current release label (from Original Release) (from Recordings) | `fldXrE14dN9EPy1a8` | Lookup                 | Array of Current release label (from Original Release) fields in linked Recordings records. |
+| Releases check                                                  | `fldJwPdhgS1EdvocV` | Lookup                 | Array of All Releases fields in linked Recordings records.                       |
+| Releases                                                        | `fldJj9yZLZEdu8qS8` | Link to another record | Array of linked records IDs from the Releases table.                             |
+| Songwriter summary                                              | `fldP5h9q03wu8d728` | Formula                | Computed value: CONCATENATE({ Songwriter 1 } & '\n' & '\n' & { Songwriter 2 } & '\n' & '\n' & { Songwriter 3 } & '\n' & '\n' & { Songwriter 4 } & '\n' & '\n' & { Songwriter 5 } & '\n' & '\n' & { Songwriter 6 } & '\n' & '\n' & { Songwriter 7 } & '\n' & '\n' & { Songwriter 8 } & '\n' & '\n' & { Songwriter 9 }) . |
+| Original Pub Summary                                            | `fldobngOfA47LjZTm` | Formula                | Computed value: CONCATENATE({ Songwriter 1 Original Pub 1 } & '\n' & '\n' & { Songwriter 1 Original Pub 2 } & '\n' & '\n' & { Songwriter 1 Original Pub 3 } & '\n' & '\n' & { Songwriter 1 Original Pub 4 } & '\n' & '\n' & { Songwriter 2 Original Pub. 1 } & '\n' & '\n' & { Songwriter 2 Original Pub. 2 } & '\n' & '\n' & { Songwriter 2 Original Pub. 3 } & '\n' & '\n' & { Songwriter 2 Original Pub 4 } & '\n' & '\n' & { Songwriter 3 Original Pub. 1 } & '\n' & '\n' & { Songwriter 3 Original Pub. 2 } & '\n' & '\n' & { Songwriter 4 Original Pub. 1 } & '\n' & '\n' & { Songwriter 4 Original Pub 2 } & '\n' & '\n' & { Songwriter 5 Original Pub. 1 } & '\n' & '\n' & { Songwriter 5 Original Pub 2 } & '\n' & '\n' & { Songwriter 6 Original Pub 1 } & '\n' & '\n' & { Songwriter 6 Original Pub. 2 } & '\n' & '\n' & { Songwriter 7 Original Pub. 1 } & '\n' & '\n' & { Songwriter 7 Original Pub. 2 } & '\n' & '\n' & { Songwriter 8 Original Pub. 1 } & '\n' & '\n' & { Songwriter 8 Original Pub. 2 } & '\n' & '\n' & { Songwriter 9 Original Pub. 1 } & '\n' & '\n' & { Songwriter 9 Original Pub. 2 }) . |
+| All Admin Publishers                                            | `fld58IACBmYnW9DJu` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Admin Pub summary                                               | `fldhb2N8dzswr8X6K` | Formula                | Computed value: CONCATENATE({ Songwriter 1 Admin Pub 1 } & '\n' & { Songwriter 1 Admin Pub 2 } & '\n' & { Songwriter 1 Admin Pub 3 } & '\n' & { Songwriter 1 Admin Pub 4 } & '\n' & { Songwriter 2 Admin Pub 1 } & '\n' & { Songwriter 2 Admin Pub. 2 } & '\n' & { Songwriter 2 Admin Pub. 3 } & '\n' & { Songwriter 2 Admin Pub 4 } & '\n' & { Songwriter 3 Admin Pub. 1 } & '\n' & { Songwriter 3 Admin Pub. 2 } & '\n' & { Songwriter 4 Admin Pub. 1 } & '\n' & { Songwriter 4 Admin Pub. 2 } & '\n' & { Songwriter 5 Admin Pub 1 } & '\n' & { Songwriter 5 Admin Pub. 2 } & '\n' & { Songwriter 6 Admin Pub. 1 } & '\n' & { Songwriter 6 Admin Pub. 2 } & '\n' & { Songwriter 7 Admin Pub. 1 } & '\n' & { Songwriter 7 Admin Pub. 2 } & '\n' & { Songwriter 8 Admin Pub. 1 } & '\n' & { Songwriter 8 Admin Pub. 2 } & '\n' & { Songwriter 9 Admin Pub. 1 } & '\n' & { Songwriter 9 Admin Pub. 2 }) . |
+| All Sub-Publishers                                              | `fldMf59kc6MdOns1n` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Sub-Pub Summary                                                 | `fld3vWOwZjiZdXTco` | Formula                | Computed value: CONCATENATE({ Songwriter 1 Sub-Pub 1 } & '\n' & '\n' & { Songwriter 2 Sub-Pub 1 } & '\n' & '\n' & { Songwriter 3 Sub-Pub 1 }) . |
+| Controlled                                                      | `fldDyYxGEbHPJuUPm` | Checkbox               | This field is "true" when checked and otherwise empty.                           |
+| PROs Involved                                                   | `fldRewvu2vu08e3aj` | Rollup                 | Computed value: ARRAYUNIQUE(values) for PRO Affiliation in Songwriters .         |
+| Involved PROs                                                   | `fldNszvBz13vnNq5h` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| PRO Summary                                                     | `fldZ0LGrupTF7ll8j` | Formula                | Computed value: CONCATENATE({ PRO Affiliation (from Songwriter 1) }, " - ", { PRO Affiliation (from Songwriter 1 Original Pub. 1) }, " - ", { PRO Affiliation (from Songwriter 1 Original Pub. 2) }, " - ", { PRO Affiliation (from Songwriter 1 Original Pub 3) }, " - ", { PRO Affiliation (from Songwriter 1 Original Pub 4) },{ PRO Affiliation (from Songwriter 2) }, " - ", { PRO Affiliation (from Songwriter 2 Original Pub. 1) }, " - ", { PRO Affiliation (from Songwriter 2 Original Pub. 2) }, " - ", { PRO Affiliation (from Songwriter 2 Original Pub. 3) }, " - ", { PRO Affiliation (from Songwriter 2 Original Pub 4) }, " - ", { PRO Affiliation (from Songwriter 3 Original Pub. 1) }, " - ", { PRO Affiliation (from Songwriter 3 Original Pub. 2) }, " - ", { PRO Affiliation (from Songwriter 4) }, " - ", { PRO Affiliation (from Songwriter 4 Original Pub.) }, " - ", { PRO Affiliation (from Songwriter 4 Original Pub 2) }, " - ", { PRO Affiliation (from Songwriter 5) }, " - ", { PRO Affiliation (from Songwriter 5 Original Pub.) }, " - ", { PRO Affiliation (from Songwriter 5 Original Pub. 2) }, " - ", { PRO Affiliation (from Songwriter 6) }, " - ", { PRO Affiliation (from Songwriter 6 Original Pub.) }, " - ", { PRO Affiliation (from Songwriter 6 Original Pub. 2) }, " - ", { PRO Affiliation (from Songwriter 7) }, " - ", { PRO Affiliation (from Songwriter 7 Original Pub.) }, " - ", { PRO Affiliation (from Songwriter 7 Original Pub. 2) }, " - ", { PRO Affiliation (from Songwriter 8) }, " - ", { PRO Affiliation (from Songwriter 8 Original Pub. 1) }, " - ", { PRO Affiliation (from Songwriter 8 Original Pub. 2) }, " - ", { PRO Affiliation (from Songwriter 9) }, " - ", { PRO Affiliation (from Songwriter 9 Original Pub. 1) }, " - ", { PRO Affiliation (from Songwriter 9 Original Pub. 2) }) . |
+| Sampled In                                                      | `fldxbJTF0hprVgoNy` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| Synchronized In                                                 | `fldbw22E1rFcWWZGO` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| Date of First Use                                               | `fldM3UkZ4xMgmSkb5` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| Intended Purpose                                                | `fldKKGcBQ0eRk7BoR` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Production Title                                                | `fldjB5BRTSHOXSQjX` | Text                   | A single line of text.                                                           |
+| PD Work Status                                                  | `fldVQAiwsIi0m1EAA` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Original PD Work Title                                          | `fldIfelxyqGVr9ZmQ` | Text                   | A single line of text.                                                           |
+| Uncredited PD Writers                                           | `fldUFeBEXjI4gjufB` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| Pub Shares Sum                                                  | `fldwjJVhTCRGzXQQ2` | Formula                | Computed value: SUM({ Songwriter 1 Original Pub 1 Share }, { Songwriter 1 Original Pub 2 Share }, { Songwriter 1 Original Pub 3 Share },{ Songwriter 1 Original Pub 4 Share }, { Songwriter 2 Original Pub. 1 Share }, { Songwriter 2 Original Pub. 2 Share }, { Songwriter 2 Original Pub 3 Share }, { Songwriter 2 Original Pub 4 Share }, { Songwriter 3 Original Pub. 1 Share }, { Songwriter 3 Original Pub. 2 Share }, { Songwriter 4 Original Pub. 1 Share }, { Songwriter 4 Original Pub 2 Share }, { Songwriter 5 Original Pub 1 Share }, { Songwriter 5 Original Pub 2 Share }, { Songwriter 6 Original Pub. 1 Share }, { Songwriter 6 Original Pub 2 Share }, { Songwriter 7 Original Pub. 1 Share }, { Songwriter 7 Original Pub. 2 Share }, { Songwriter 8 Original Pub. 1 Share }, { Songwriter 8 Original Pub. 2 Share }, { Songwriter 9 Original Pub. 1 Share }, { Songwriter 9 Original Pub. 2 Share }) . |
+| Songwriter 1                                                    | `fldLhXZcoaevUSLlA` | Link to another record | Array of linked records IDs from the Songwriters table.                          |
+| Songwriter 1 Share                                              | `fldqFoYcdP4QpRtlF` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 1 Role                                               | `fld2hxd4Snp1BYSar` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Songwriter 1 Original Pub 1                                     | `fldcx8y9D1KbIfCCj` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 1 Original Pub 1 Share                               | `fldcjWL6czrFQfEtU` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 1 Admin Pub 1                                        | `fldeNG9WWWEeKzHpN` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Email (from Songwriter 1 Admin Pub 1)                           | `fldLYqBaQn7RI0b47` | Lookup                 | Array of Email fields in linked Publishers records.                              |
+| Address (from Songwriter 1 Admin Pub 1)                         | `fldQxH0nR1LdbRSCS` | Lookup                 | Array of Address fields in linked Publishers records.                            |
+| Songwriter 1 Sub-Pub 1                                          | `fldMi4ctlHPOaPFMD` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 1 Original Pub 2                                     | `fldmeUuHY6dE7eRuq` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 1 Original Pub 2 Share                               | `fldT7ce7D97Avdfb0` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 1 Admin Pub 2                                        | `fldidUvdgDagDJ1rf` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Email (from Songwriter 1 Admin Pub 2)                           | `fld80psfK3ChBpfGQ` | Lookup                 | Array of Email fields in linked Publishers records.                              |
+| Address (from Songwriter 1 Admin Pub 2)                         | `fldkh6goyYT6R180j` | Lookup                 | Array of Address fields in linked Publishers records.                            |
+| Songwriter 1 Original Pub 3                                     | `fldsKbymynSOfi6rQ` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 1 Original Pub 3 Share                               | `fld5BAlh8bUNmROPu` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 1 Admin Pub 3                                        | `fldYrbODcYavzhqbM` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 1 Original Pub 4                                     | `fldgHvCEX0OIRYscT` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 1 Original Pub 4 Share                               | `fldLIgL3205HD0t4Y` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 1 Admin Pub 4                                        | `fldNnONxuj9KnFxnu` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 2                                                    | `fldeivT63AcOXMinA` | Link to another record | Array of linked records IDs from the Songwriters table.                          |
+| Songwriter 2 Share                                              | `fldwYiUeQgQID1ehO` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 2 Role                                               | `fldjTMZcewms7A4Y9` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Songwriter 2 Original Pub. 1                                    | `fld4085JeJSnRKbhA` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 2 Original Pub. 1 Share                              | `fldqMemokLaBF4OaK` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 2 Admin Pub 1                                        | `fld2pifFJ2sg6UMRo` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Email (from Songwriter 2 Admin Pub 1)                           | `fldtuS8FF7yFxCzin` | Lookup                 | Array of Email fields in linked Publishers records.                              |
+| Address (from Songwriter 2 Admin Pub 1)                         | `fldLykzU0L6kfGi3A` | Lookup                 | Array of Address fields in linked Publishers records.                            |
+| Songwriter 2 Sub-Pub 1                                          | `fld9zTSYx2pv31dxT` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 2 Original Pub. 2                                    | `fld42MeLzoYB1jYC4` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 2 Original Pub. 2 Share                              | `fldxFU6Xcq3BINcc5` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 2 Admin Pub. 2                                       | `fldKbVO7wYpvXzpUK` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Email (from Songwriter 2 Admin Pub. 2)                          | `fldsMjS4XKAJpBhSq` | Lookup                 | Array of Email fields in linked Publishers records.                              |
+| Address (from Songwriter 2 Admin Pub. 2)                        | `fldmkPbUQODmoB72j` | Lookup                 | Array of Address fields in linked Publishers records.                            |
+| Songwriter 2 Original Pub. 3                                    | `fldV0guqfaRzYaOql` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 2 Original Pub 3 Share                               | `fld9TU2v36ZlYsm0v` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 2 Admin Pub. 3                                       | `fldEwxZB6t2ApprA9` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 2 Original Pub 4                                     | `fldZjIC9fyswqRfOa` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 2 Original Pub 4 Share                               | `fldovV2KQZyo8a8CR` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 2 Admin Pub 4                                        | `fld0fCbtnmVTHcKC8` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 3                                                    | `fldpQwAEw0mATtMW4` | Link to another record | Array of linked records IDs from the Songwriters table.                          |
+| Songwriter 3 Ownership                                          | `fldPwg7CGdho4EERI` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 3 Role                                               | `fldp5WGgspZEA4iTF` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Songwriter 3 Original Pub. 1                                    | `fldVAiZ0RFyEih9HO` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 3 Original Pub. 1 Share                              | `fld6pjTCxLGLL9jsQ` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 3 Admin Pub. 1                                       | `fldiKRkycbb71x06O` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Email (from Songwriter 3 Admin Pub. 1)                          | `fld3CtgxdUGHCRhFl` | Lookup                 | Array of Email fields in linked Publishers records.                              |
+| Address (from Songwriter 3 Admin Pub. 1)                        | `fldAyXZIIQcuMD7xz` | Lookup                 | Array of Address fields in linked Publishers records.                            |
+| Songwriter 3 Sub-Pub 1                                          | `fld8ssi2tFWvUy7WO` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 3 Original Pub. 2                                    | `fldH8we533t41M6B7` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 3 Original Pub. 2 Share                              | `fld0rjCDUUqVWi4dj` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 3 Admin Pub. 2                                       | `fldY3XaFcn8EZD8Sw` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Email (from Songwriter 3 Admin Pub. 2)                          | `fldCdSlkIXmdImCx8` | Lookup                 | Array of Email fields in linked Publishers records.                              |
+| Address (from Songwriter 3 Admin Pub. 2)                        | `fldBYKaEFIVSiFIDX` | Lookup                 | Array of Address fields in linked Publishers records.                            |
+| Songwriter 4                                                    | `fldfi9zF7k7eyzN3E` | Link to another record | Array of linked records IDs from the Songwriters table.                          |
+| Songwriter 4 Ownership                                          | `fldZLBA62pZY5BCWC` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 4 Role                                               | `fldXkpl6ajr53tAZX` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Songwriter 4 Original Pub. 1                                    | `fldqbaFomnWoWwRwi` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 4 Original Pub. 1 Share                              | `fldRxaAOwxMiq9hKG` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 4 Admin Pub. 1                                       | `fldqXGTiRaLiF4ZKx` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Email (from Songwriter 4 Admin Pub. 1)                          | `fldbuuosV9OG539NU` | Lookup                 | Array of Email fields in linked Publishers records.                              |
+| Address (from Songwriter 4 Admin Pub. 1)                        | `fldSB0rNIem3bpPiN` | Lookup                 | Array of Address fields in linked Publishers records.                            |
+| Songwriter 4 Original Pub 2                                     | `fldgSXi7ij2SZGL28` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 4 Original Pub 2 Share                               | `fldbJ3lCeOiTRrEbH` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 4 Admin Pub. 2                                       | `fldmhqgbvPmw6OZZz` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Email (from Songwriter 4 Admin Pub. 2)                          | `fld6VWSTLWM73f60P` | Lookup                 | Array of Email fields in linked Publishers records.                              |
+| Address (from Songwriter 4 Admin Pub. 2)                        | `fld6RUAtHxZGyo9MG` | Lookup                 | Array of Address fields in linked Publishers records.                            |
+| Songwriter 5                                                    | `fld94WOrOzwY3ZZr4` | Link to another record | Array of linked records IDs from the Songwriters table.                          |
+| Songwriter 5 Ownership                                          | `fldcPl10fIN2QCzQs` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 5 Role                                               | `fldrwWbIA93TfKcYj` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Songwriter 5 Original Pub. 1                                    | `fldwZSHeismDTtoRm` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 5 Original Pub 1 Share                               | `fld9kyPJFdX1BP4Qq` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 5 Admin Pub 1                                        | `fldTBUGYFJFk2GA0k` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Email (from Songwriter 5 Admin Pub 1)                           | `fldHjL9fugVZfypap` | Lookup                 | Array of Email fields in linked Publishers records.                              |
+| Address (from Songwriter 5 Admin Pub 1)                         | `fld8iqm9SgXThiXV5` | Lookup                 | Array of Address fields in linked Publishers records.                            |
+| Songwriter 5 Original Pub 2                                     | `fldRnZsO4lwV3KZUI` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 5 Original Pub 2 Share                               | `fldNT3ZnLcv0YWTcT` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 5 Admin Pub. 2                                       | `fld6vKaTX4kahUg8Z` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 6                                                    | `fldspvCZJR5LI2KMM` | Link to another record | Array of linked records IDs from the Songwriters table.                          |
+| Songwriter 6 Ownership                                          | `fldmGV25Xmn52pOFk` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 6 Role                                               | `fldi6f61AFXfQdDQc` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Songwriter 6 Original Pub 1                                     | `fldGo6i2jCDh3VWYM` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 6 Original Pub. 1 Share                              | `fldTcZbo0OnEz2W35` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 6 Admin Pub. 1                                       | `fldupwtvdkBPnmeUv` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Email (from Songwriter 6 Admin Pub. 1)                          | `fldJsfFMTnbIsVwSm` | Lookup                 | Array of Email fields in linked Publishers records.                              |
+| Address (from Songwriter 6 Admin Pub. 1)                        | `fldqTMPuXXYfI2kxA` | Lookup                 | Array of Address fields in linked Publishers records.                            |
+| Songwriter 6 Original Pub. 2                                    | `fldsff6W3SRZP94yZ` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 6 Original Pub 2 Share                               | `flds3ZoHEQmF8BiiV` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 6 Admin Pub. 2                                       | `fld7CY20AWkc1SIxL` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 7                                                    | `fldd3R26JG9uqgw9P` | Link to another record | Array of linked records IDs from the Songwriters table.                          |
+| Songwriter 7 Ownership                                          | `fldQUWOo35DLUH5n0` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 7 Role                                               | `fldAItKGSrHOI3acu` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Songwriter 7 Original Pub. 1                                    | `fldVFyqtVZKZFDxUc` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 7 Original Pub. 1 Share                              | `fldH8mlANOgZirTry` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 7 Admin Pub. 1                                       | `fldsCeVEfrGptKpJc` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 7 Original Pub. 2                                    | `fldazkIgA8HSKPFzf` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 7 Original Pub. 2 Share                              | `fld9C5blDReVxqTA5` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 7 Admin Pub. 2                                       | `fld5X2SFPOQxz3mmS` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 8                                                    | `fldCtxeKcFoop5kpv` | Link to another record | Array of linked records IDs from the Songwriters table.                          |
+| Songwriter 8 Ownership                                          | `fldF0cPRWx2Vj2LkO` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 8 Role                                               | `fldZTovycBXkCEsnf` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Songwriter 8 Original Pub. 1                                    | `fldg4VsKIA2ABmEY7` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 8 Original Pub. 1 Share                              | `fldV3wsYTeC80U9eW` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 8 Admin Pub. 1                                       | `fld4Q0oVqasrLgOPZ` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 8 Original Pub. 2                                    | `fldTo9U34nKjusDtc` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 8 Original Pub. 2 Share                              | `fldZUnxSLNhQVqpT2` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 8 Admin Pub. 2                                       | `flduz0piEiv2ES4Xi` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 9                                                    | `fld3prOTF7TdS4cdj` | Link to another record | Array of linked records IDs from the Songwriters table.                          |
+| Songwriter 9 Ownership                                          | `fldNRMQs43NLo7Vqy` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 9 Role                                               | `fldOyDUgBJ6QaVtqc` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Songwriter 9 Original Pub. 1                                    | `fldPr6m9Tnf83vlJ0` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 9 Original Pub. 1 Share                              | `fld02yPYOQFjZnSE6` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 9 Admin Pub. 1                                       | `fldM8ji8hdvlOs2qX` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 9 Original Pub. 2                                    | `fldqpQsw8XYay8Etm` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter 9 Original Pub. 2 Share                              | `fldnjAbT0VpICSyQX` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Songwriter 9 Admin Pub. 2                                       | `fldwqtEg520xFlCRz` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| PRO Affiliation (from Songwriter 1)                             | `fldZpAplK0s7RpOcQ` | Lookup                 | Array of PRO Affiliation fields in linked Songwriters records.                   |
+| IPI Number (from Songwriter 1)                                  | `fldUVUp6yVxCyP7Kj` | Lookup                 | Array of IPI Number fields in linked Songwriters records.                        |
+| PRO Affiliation (from Songwriter 1 Original Pub. 1)             | `fldaVyfSSWqMoyb6C` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| IPI/CAE Number (from Songwriter 1 Original Pub. 1)              | `fldOPpEeK8Ixpb7GC` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| Featured Artist (from Recordings)                               | `fldeI1ylIFh8CDeHi` | Lookup                 | Array of Featured Artist fields in linked Recordings records.                    |
+| PRO Affiliation (from Songwriter 2)                             | `fld1y1SUwQnTraFga` | Lookup                 | Array of PRO Affiliation fields in linked Songwriters records.                   |
+| IPI Number (from Songwriter 2)                                  | `fldhgeTSKSG8LnzZF` | Lookup                 | Array of IPI Number fields in linked Songwriters records.                        |
+| PRO Affiliation (from Songwriter 2 Original Pub. 1)             | `fldsH4InPf44LKqFn` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| IPI/CAE Number (from Songwriter 2 Original Pub. 1)              | `fldFXZjq9kZG6e9Qw` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| PRO Affiliation (from Songwriter 2 Original Pub. 2)             | `fldj0tfaWhUSV7Oha` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| IPI/CAE Number (from Songwriter 2 Original Pub. 2)              | `fldPyQXMz0UUuXN04` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| PRO Affiliation (from Songwriter 3)                             | `fldYHZj7kClFnib8z` | Lookup                 | Array of PRO Affiliation fields in linked Songwriters records.                   |
+| IPI Number (from Songwriter 3)                                  | `fldrywzlTAuEkZm7y` | Lookup                 | Array of IPI Number fields in linked Songwriters records.                        |
+| PRO Affiliation (from Songwriter 3 Original Pub. 1)             | `fldmxjYuJBKaq8THm` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| IPI/CAE Number (from Songwriter 3 Original Pub. 1)              | `fldTczYCRTz3XhEcR` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| PRO Affiliation (from Songwriter 4)                             | `fldzAIgH7JcKhq2xF` | Lookup                 | Array of PRO Affiliation fields in linked Songwriters records.                   |
+| IPI Number (from Songwriter 4)                                  | `fldFHdc0gyxrvTjmb` | Lookup                 | Array of IPI Number fields in linked Songwriters records.                        |
+| PRO Affiliation (from Songwriter 4 Original Pub.)               | `fldb28DI0h05M3YxJ` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| IPI/CAE Number (from Songwriter 4 Original Pub.)                | `fldv0RdxqO8BLAdzA` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| PRO Affiliation (from Songwriter 5)                             | `fldIZVC6TDWeFsmE1` | Lookup                 | Array of PRO Affiliation fields in linked Songwriters records.                   |
+| IPI Number (from Songwriter 5)                                  | `fld3Sxtjs0wwmonwD` | Lookup                 | Array of IPI Number fields in linked Songwriters records.                        |
+| PRO Affiliation (from Songwriter 5 Original Pub.)               | `fldUf6pgQ69WTSPvQ` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| IPI/CAE Number (from Songwriter 5 Original Pub.)                | `fldFHTtUptVn8QxVe` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| PRO Affiliation (from Songwriter 6)                             | `fldRFn0eQZZJtTylm` | Lookup                 | Array of PRO Affiliation fields in linked Songwriters records.                   |
+| IPI Number (from Songwriter 6)                                  | `fldrrOqnyPscVXLo9` | Lookup                 | Array of IPI Number fields in linked Songwriters records.                        |
+| PRO Affiliation (from Songwriter 6 Original Pub.)               | `fldNZ1kTvmwUJItYy` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| IPI/CAE Number (from Songwriter 6 Original Pub.)                | `fldxJXDmgTo3eaJfP` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| PRO Affiliation (from Songwriter 7)                             | `fldak8wx4TeBZbDnP` | Lookup                 | Array of PRO Affiliation fields in linked Songwriters records.                   |
+| IPI Number (from Songwriter 7)                                  | `fldchUbmHnPlnKtGi` | Lookup                 | Array of IPI Number fields in linked Songwriters records.                        |
+| PRO Affiliation (from Songwriter 7 Original Pub.)               | `fldjwdGta3MveOiGx` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| IPI/CAE Number (from Songwriter 7 Original Pub.)                | `fldK684XXyjvnE2xK` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| Controlled (from Songwriter 1 Original Pub. 1)                  | `fldJktT1FPSQyBrwD` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| Controlled (from Songwriter 2 Original Pub. 1)                  | `fldl8vSiEmVTaHwTh` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| Controlled (from Songwriter 1 Original Pub. 2)                  | `fldySuCEP7We7gqes` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| PRO Affiliation (from Songwriter 1 Original Pub. 2)             | `fld4rzUIs0QP1VBHM` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| IPI/CAE Number (from Songwriter 1 Original Pub. 2)              | `fldjzQgjRKrQQqZXD` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| Controlled (from Songwriter 1 Original Pub 3)                   | `fldPtyucbtgmFB2Q3` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| PRO Affiliation (from Songwriter 1 Original Pub 3)              | `fldF06ZCm5Mr0iDVJ` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| Controlled (from Songwriter 2 Original Pub. 2)                  | `fldClmLaMFg5ocfbw` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| Controlled (from Songwriter 2 Original Pub. 3)                  | `fldqhdAlrV44Ge1qj` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| PRO Affiliation (from Songwriter 2 Original Pub. 3)             | `fldWWXq8rIjWIWdxV` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| IPI/CAE Number (from Songwriter 2 Original Pub. 3)              | `fldqfocP9ZOPgLwp8` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| Controlled (from Songwriter 3 Original Pub. 1)                  | `fldb0MhnCyRnl63FU` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| Controlled (from Songwriter 3 Original Pub. 2)                  | `fldfvzzrZUi6d0dCC` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| PRO Affiliation (from Songwriter 3 Original Pub. 2)             | `fld75btrRxj3FMbHz` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| IPI/CAE Number (from Songwriter 3 Original Pub. 2)              | `fldmAOyXOnPACQj3Q` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| IPI/CAE Number (from Songwriter 1 Original Pub 3)               | `fldsU3nry63zKgf5B` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| Controlled (from Songwriter 4 Original Pub. 1)                  | `fldIhr8g0BUZ9ZCnB` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| PRO Affiliation (from Songwriter 4 Original Pub 2)              | `fld9v9sXRHUxhDLSp` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| IPI/CAE Number (from Songwriter 4 Original Pub 2)               | `fldPCBNaijdtTI6JA` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| Box Spreadsheet (from Releases)                                 | `fldxNglrwk777jG3p` | Lookup                 | Array of Box Spreadsheet fields in linked Releases records.                      |
+| Controlled (from Songwriter 4 Original Pub 2)                   | `fldTrq8syNb9canOr` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| Controlled (from Songwriter 5 Original Pub. 1)                  | `fldqkDZvegpEQ2Kgf` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| Controlled (from Songwriter 5 Original Pub. 2)                  | `fldD2jQbeBVKG3YR4` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| PRO Affiliation (from Songwriter 5 Original Pub. 2)             | `fldTGLWugJYgoOK5U` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| IPI/CAE Number (from Songwriter 5 Original Pub. 2)              | `fldQE9uEOw4cYuRy9` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| Controlled (from Songwriter 6 Original Pub. 1)                  | `fldpv4XdcVzHHGotT` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| Controlled (from Songwriter 6 Original Pub. 2)                  | `fldURLSPxMOkcTAF2` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| PRO Affiliation (from Songwriter 6 Original Pub. 2)             | `fldN6AJhMESt1XUpE` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| IPI/CAE Number (from Songwriter 6 Original Pub. 2)              | `fldm6NAVvKfbjh5na` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| Controlled (from Songwriter 7 Original Pub. 1)                  | `fldV4cNP6O3op9HXL` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| Controlled (from Songwriter 7 Original Pub. 2)                  | `fld79XiBuNrixCWkW` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| PRO Affiliation (from Songwriter 7 Original Pub. 2)             | `fldfv11ObHYZPqxP4` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| IPI/CAE Number (from Songwriter 7 Original Pub. 2)              | `fldBTgR7IrdL0Beg0` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| PRO Affiliation (from Songwriter 8)                             | `fldKv3aQB3IUpLjZ5` | Lookup                 | Array of PRO Affiliation fields in linked Songwriters records.                   |
+| IPI Number (from Songwriter 8)                                  | `fld9JMRRVmKiVVS0q` | Lookup                 | Array of IPI Number fields in linked Songwriters records.                        |
+| Controlled (from Songwriter 8 Original Pub. 1)                  | `fldBGq21mnjSaTOko` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| PRO Affiliation (from Songwriter 8 Original Pub. 1)             | `fldbIeO6X5ECJ6HA5` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| IPI/CAE Number (from Songwriter 8 Original Pub. 1)              | `fldoztvhwEcQAxrzc` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| Controlled (from Songwriter 8 Original Pub. 2)                  | `fld3cFxRmvm9xzCbU` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| PRO Affiliation (from Songwriter 8 Original Pub. 2)             | `fldk5m3Y3CU3VBrH2` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| IPI/CAE Number (from Songwriter 8 Original Pub. 2)              | `fld0lAGDHMXuQOo3p` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| PRO Affiliation (from Songwriter 9)                             | `fldgDPGjZuJ8jOxEL` | Lookup                 | Array of PRO Affiliation fields in linked Songwriters records.                   |
+| IPI Number (from Songwriter 9)                                  | `fldKbnh7YZF3bApkf` | Lookup                 | Array of IPI Number fields in linked Songwriters records.                        |
+| Controlled (from Songwriter 9 Original Pub. 1)                  | `fld1e0mq4sL9UnZaT` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| PRO Affiliation (from Songwriter 9 Original Pub. 1)             | `fldp364WYVkTyO195` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| IPI/CAE Number (from Songwriter 9 Original Pub. 1)              | `fldd07rtpQP1sJgN7` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| Controlled (from Songwriter 9 Original Pub. 2)                  | `fld4ITQVARHrvCTQe` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| PRO Affiliation (from Songwriter 9 Original Pub. 2)             | `fldxVPdyalvC18WtA` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| IPI/CAE Number (from Songwriter 9 Original Pub. 2)              | `fld1YUpRBaoe1duaY` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| Controlled (from Songwriter 1 Original Pub 4)                   | `fld2Q6xn4XYDJvK7s` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| PRO Affiliation (from Songwriter 1 Original Pub 4)              | `fldlg5jKyjX2UeHIG` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| IPI/CAE Number (from Songwriter 1 Original Pub 4)               | `fldXfUSgn4QZ3LKhW` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| Controlled (from Songwriter 2 Original Pub 4)                   | `fldOc8soymVNUt888` | Lookup                 | Array of Controlled fields in linked Publishers records.                         |
+| PRO Affiliation (from Songwriter 2 Original Pub 4)              | `fldb8BhQ5AEbsE3FZ` | Lookup                 | Array of PRO Affiliation fields in linked Publishers records.                    |
+| IPI/CAE Number (from Songwriter 2 Original Pub 4)               | `fldDAE1u56iBXkoUJ` | Lookup                 | Array of IPI/CAE Number fields in linked Publishers records.                     |
+| REGISTRATION PROJECT (PRO +MLC) copy                            | `fldYnDMpmxRN1vBeQ` | Text                   | A single line of text.                                                           |
+| Recordings 2                                                    | `fldxWNmJpXpvsObEg` | Link to another record | Array of linked records IDs from the Recordings table.                           |
+| Releases 2                                                      | `fldQlJmvFWq4ipS17` | Link to another record | Array of linked records IDs from the Releases table.                             |
+| Release Date (from Releases 2)                                  | `fldlNWy5sLA4YHzjK` | Lookup                 | Array of Release Date fields in linked Releases records.                         |
+| Releases 3                                                      | `fldF908RO6LCB39D5` | Link to another record | Array of linked records IDs from the Releases table.                             |
+| Recordings (from Releases 3)                                    | `fldjzsZvJd1yTWudx` | Lookup                 | Array of Recordings fields in linked Releases records.                           |
+| Release Date (from Releases 3)                                  | `fldYDKLUSWQJylLXA` | Lookup                 | Array of Release Date fields in linked Releases records.                         |
+| Release Title (from Releases 3)                                 | `fldE0hfQZUoiDePU4` | Lookup                 | Array of Release Title fields in linked Releases records.                        |
+| Recordings 3                                                    | `fldYObdWITjl5fAAO` | Link to another record | Array of linked records IDs from the Recordings table.                           |
+| Controlled by HFA (from Songwriter 1 Original Pub 1)            | `fldN5aPWhP55kgX3s` | Lookup                 | Array of Controlled by HFA fields in linked Publishers records.                  |
+| Controlled by HFA (from Songwriter 1 Admin Pub 1)               | `fld4DKw7zdAJZGe2T` | Lookup                 | Array of Controlled by HFA fields in linked Publishers records.                  |
+| Controlled by HFA (from Songwriter 1 Original Pub 2)            | `fldPT7BEHId5wNzJG` | Lookup                 | Array of Controlled by HFA fields in linked Publishers records.                  |
+| Controlled by HFA (from Songwriter 1 Admin Pub 2)               | `fldS4xQXLj1tKxmGH` | Lookup                 | Array of Controlled by HFA fields in linked Publishers records.                  |
+| Controlled by HFA (from Songwriter 2 Original Pub. 1)           | `fldgDqd3sKA5jdGKT` | Lookup                 | Array of Controlled by HFA fields in linked Publishers records.                  |
+| Controlled by HFA (from Songwriter 2 Admin Pub 1)               | `fld6WbYUVRNt7nw69` | Lookup                 | Array of Controlled by HFA fields in linked Publishers records.                  |
+| Controlled by HFA (from Songwriter 2 Original Pub. 2)           | `fldo3J7VccQiNP5Fd` | Lookup                 | Array of Controlled by HFA fields in linked Publishers records.                  |
+| Controlled by HFA (from Songwriter 2 Admin Pub. 2)              | `fldyJsiEKxkCSZhxE` | Lookup                 | Array of Controlled by HFA fields in linked Publishers records.                  |
+| Controlled by HFA (from Songwriter 3 Original Pub. 1)           | `fldKZkuyGDZ543HJi` | Lookup                 | Array of Controlled by HFA fields in linked Publishers records.                  |
+| Controlled by HFA (from Songwriter 3 Admin Pub. 1)              | `fld1pWUO1LKNhOkgz` | Lookup                 | Array of Controlled by HFA fields in linked Publishers records.                  |
+| Controlled by HFA (from Songwriter 3 Original Pub. 2)           | `fldrZqvXVvzpX1e44` | Lookup                 | Array of Controlled by HFA fields in linked Publishers records.                  |
+| Controlled by HFA (from Songwriter 3 Admin Pub. 2)              | `fldnbUCHZ2LoILIkc` | Lookup                 | Array of Controlled by HFA fields in linked Publishers records.                  |
+| Controlled by HFA (from Songwriter 4 Original Pub. 1)           | `fldugZiK0H2MZRPGQ` | Lookup                 | Array of Controlled by HFA fields in linked Publishers records.                  |
+| Controlled by HFA (from Songwriter 4 Admin Pub. 1)              | `fldacIAYuLTMjoGTt` | Lookup                 | Array of Controlled by HFA fields in linked Publishers records.                  |
+| Controlled by HFA (from Songwriter 4 Original Pub 2)            | `fldQudEQaBHDOBCwF` | Lookup                 | Array of Controlled by HFA fields in linked Publishers records.                  |
+| Controlled by HFA (from Songwriter 4 Admin Pub. 2)              | `flduW59GMKsVyqIVL` | Lookup                 | Array of Controlled by HFA fields in linked Publishers records.                  |
+| SoT Transition Status                                           | `fldBIeO6MbeeCKGRx` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Legal Docs                                                      | `fldh0MvKdlr37yU6N` | Link to another record | Array of linked records IDs from the Legal Docs table.                           |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/compositions`
+
+To list records in Compositions , issue a GET request to the Compositions endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Returned records do not include any fields with "empty" values, e.g. "" , [] , or false .
+
+```bash
+curl "https://api.airtable.com/v0/appEurfA8kXQE3slK/Compositions?maxRecords=3&view=When%20You%20Wish%20-%20ASCAP%20Registration" \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+### Query Parameters
+
+| Parameter               | Type             | Required   | Description                                                                      |
+| ----------------------- | ---------------- | ---------- | -------------------------------------------------------------------------------- |
+| `fields`                | array of strings | optional   | Only data for fields whose names are in this list will be included in the result. If you don't need every field, you can use this parameter to reduce the amount of data transferred. For example, to only return data from Song Title In PRO and Notes , send these two query parameters: fields%5B%5D=Song |
+| `filterByFormula`       | string           | optional   | A formula used to filter records. The formula will be evaluated for each record, and if the result is not 0 , false , "" , NaN , [] , or #Error! the record will be included in the response. We recommend testing your formula in the Formula field UI before using it in your API request. If combined wit |
+| `maxRecords`            | number           | optional   | The maximum total number of records that will be returned in your requests. If this value is larger than pageSize (which is 100 by default), you may have to load multiple pages to reach this total. See the Pagination section below for more. |
+| `pageSize`              | number           | optional   | The number of records returned in each request. Must be less than or equal to 100. Default is 100. See the Pagination section below for more. |
+| `sort`                  | array of objects | optional   | A list of sort objects that specifies how the records will be ordered. Each sort object must have a field key specifying the name of the field to sort on, and an optional direction key that is either "asc" or "desc" . The default direction is "asc" . The sort parameter overrides the sorting of the v |
+| `view`                  | string           | optional   | The name or ID of a view in the Compositions table. If set, only the records in that view will be returned. The records will be sorted according to the order of the view unless the sort parameter is included, which overrides that order. Fields hidden in this view will be returned in the results. To |
+| `cellFormat`            | string           | optional   | The format that should be used for cell values. Supported values are: json : cells will be formatted as JSON, depending on the field type. string : cells will be formatted as user-facing strings, regardless of the field type. The timeZone and userLocale parameters are required when using string as t |
+| `timeZone`              | string           | optional   | The time zone that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `userLocale`            | string           | optional   | The user locale that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `returnFieldsByFieldId` | boolean          | optional   | An optional boolean value that lets you return field objects where the key is the field id. This defaults to false , which returns field objects where the key is the field name. |
+| `recordMetadata`        | array of strings | optional   | An optional field that, if includes commentCount , adds a commentCount read only property on each record returned. |
+
+---
+
+## Retrieve a Record
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/compositions`
+
+To retrieve an existing record in Compositions table, issue a GET request to the record endpoint.
+
+Any "empty" fields (e.g. "" , [] , or false ) in the record will not be returned.
+
+```bash
+curl https://api.airtable.com/v0/appEurfA8kXQE3slK/Compositions/recpfoXpd6eXqejHT \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+---
+
+## Create Records
+
+**Endpoint:** `POST /v0/appEurfA8kXQE3slK/compositions`
+
+To create new records, issue a POST request to the Compositions endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have one key whose value is an inner object containing your record's cell values, keyed by either field name or field id.
+
+```bash
+curl -X POST https://api.airtable.com/v0/appEurfA8kXQE3slK/Compositions \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "fields": {
+        "Song Title In PRO": "5 10 15 HOURS",
+        "ISWC": "T0709409551\n",
+        "Recordings": [
+          "recrrRaUSA1Ylwao0",
+          "recpYSxdWCSj7g6i4"
+        ],
+        "All Songwriters": [
+          "recjwnR93dvVoDEzf"
+        ],
+        "All Original Publishers": [
+          "recf9b8XcWWtNVbzq"
+        ],
+        "All Admin Publishers": [
+          "rectT66YlZP9naK6B"
+        ],
+        "Involved PROs": [
+          "BMI"
+        ],
+        "Songwriter 1": [
+          "recjwnR93dvVoDEzf"
+        ],
+        "Songwriter 1 Share": 1,
+        "Songwriter 1 Role": [
+          "Composer"
+        ],
+        "Songwriter 1 Original Pub 1": [
+          "recf9b8XcWWtNVbzq"
+        ],
+        "Songwriter 1 Original Pub 1 Share": 1,
+        "Songwriter 1 Admin Pub 1": [
+          "rectT66YlZP9naK6B"
+        ]
+      }
+    },
+    {
+      "fields": {
+        "Song Title In PRO": "A B C CHEVY THEME",
+        "Notes": "ASCAP Work ID: 310000110",
+        "ISWC": "T0700000527",
+        "All Songwriters": [
+          "rech43fjOfIJh8XJt"
+        ],
+        "Songwriter 1": [
+          "rech43fjOfIJh8XJt"
+        ],
+        "Songwriter 1 Share": 1,
+        "Songwriter 1 Original Pub 1": [
+          "recpbxExDaBhGyWkS"
+        ],
+        "Songwriter 1 Original Pub 1 Share": 1
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Update / Upsert Records
+
+**Endpoint:** `PATCH /v0/appEurfA8kXQE3slK/compositions`
+
+To update Compositions records, issue a request to the Compositions endpoint. Table names and table IDs can be used interchangeably. Using table IDs means table name changes won't require modifying your API request code. A PATCH request will only update the fields included in the request. Fields not included in the request will be unchanged. A PUT request will perform a destructive update and clear all unincluded cell values.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have an id property representing the record ID and a fields property which contains all of your record's cell values by field name or field id for all of your record's cell values by field name.
+
+```bash
+curl -X PATCH https://api.airtable.com/v0/appEurfA8kXQE3slK/Compositions \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "id": "recpfoXpd6eXqejHT",
+      "fields": {
+        "Song Title In PRO": "5 10 15 HOURS",
+        "ISWC": "T0709409551\n",
+        "Recordings": [
+          "recrrRaUSA1Ylwao0",
+          "recpYSxdWCSj7g6i4"
+        ],
+        "All Songwriters": [
+          "recjwnR93dvVoDEzf"
+        ],
+        "All Original Publishers": [
+          "recf9b8XcWWtNVbzq"
+        ],
+        "All Admin Publishers": [
+          "rectT66YlZP9naK6B"
+        ],
+        "Involved PROs": [
+          "BMI"
+        ],
+        "Songwriter 1": [
+          "recjwnR93dvVoDEzf"
+        ],
+        "Songwriter 1 Share": 1,
+        "Songwriter 1 Role": [
+          "Composer"
+        ],
+        "Songwriter 1 Original Pub 1": [
+          "recf9b8XcWWtNVbzq"
+        ],
+        "Songwriter 1 Original Pub 1 Share": 1,
+        "Songwriter 1 Admin Pub 1": [
+          "rectT66YlZP9naK6B"
+        ]
+      }
+    },
+    {
+      "id": "rec2XT7Snrjqjz6Lk",
+      "fields": {
+        "Song Title In PRO": "A B C CHEVY THEME",
+        "Notes": "ASCAP Work ID: 310000110",
+        "ISWC": "T0700000527",
+        "All Songwriters": [
+          "rech43fjOfIJh8XJt"
+        ],
+        "Songwriter 1": [
+          "rech43fjOfIJh8XJt"
+        ],
+        "Songwriter 1 Share": 1,
+        "Songwriter 1 Original Pub 1": [
+          "recpbxExDaBhGyWkS"
+        ],
+        "Songwriter 1 Original Pub 1 Share": 1
+      }
+    },
+    {
+      "id": "rec7gRiSnrewh609G",
+      "fields": {
+        "Song Title In PRO": "A CONCERTO FOR CHOPSTICKS ",
+        "Notes": "Public Domain work: https://en.wikipedia.org/wiki/Chopsticks_(waltz)\nComposer: Euphemia Allen",
+        "Recordings": [
+          "rechetrnVRLHCZte5"
+        ],
+        "Date of First Use": "1877",
+        "PD Work Status": "Arrangement of Original PD Work",
+        "Uncredited PD Writers": "Euphemia Allen"
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Delete Records
+
+**Endpoint:** `DELETE /v0/appEurfA8kXQE3slK/compositions`
+
+To delete Compositions records, issue a DELETE request to the Compositions endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request should include a URL-encoded array of up to 10 record IDs to delete.
+
+```bash
+curl -X DELETE https://api.airtable.com/v0/appEurfA8kXQE3slK/Compositions \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -G \
+  --data-urlencode 'records[]=recpfoXpd6eXqejHT' \
+  --data-urlencode 'records[]=rec2XT7Snrjqjz6Lk'
+```
+

--- a/DOCS/AIRTABLE_API/dot-records-data.md
+++ b/DOCS/AIRTABLE_API/dot-records-data.md
@@ -1,0 +1,161 @@
+# Dot Records Data
+
+**Table ID:** `tblqz34c9YV44cqGl`  
+**Base ID:** `appEurfA8kXQE3slK`
+
+---
+
+## Fields
+
+| Field Name           | Field ID            | Type          | Description                                                                      |
+| -------------------- | ------------------- | ------------- | -------------------------------------------------------------------------------- |
+| Release Label        | `fldIO5M0x4lneznJv` | Text          | A single line of text.                                                           |
+| Album / Single Title | `fldgifOqao5Jkge79` | Text          | A single line of text.                                                           |
+| Date                 | `fldyMurLJpqd3uXkv` | Text          | A single line of text.                                                           |
+| Status               | `fldB2E0npPyWF5J3v` | Checkbox      | This field is "true" when checked and otherwise empty.                           |
+| Collaborator         | `fldwzzfARNka11UAP` | Single select | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/dot%20records%20data`
+
+To list records in Dot Records Data , issue a GET request to the Dot Records Data endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Returned records do not include any fields with "empty" values, e.g. "" , [] , or false .
+
+```bash
+curl "https://api.airtable.com/v0/appEurfA8kXQE3slK/Dot%20Records%20Data?maxRecords=3&view=Grid%20view" \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+### Query Parameters
+
+| Parameter               | Type             | Required   | Description                                                                      |
+| ----------------------- | ---------------- | ---------- | -------------------------------------------------------------------------------- |
+| `fields`                | array of strings | optional   | Only data for fields whose names are in this list will be included in the result. If you don't need every field, you can use this parameter to reduce the amount of data transferred. For example, to only return data from Release Label and Album / Single Title , send these two query parameters: fields |
+| `filterByFormula`       | string           | optional   | A formula used to filter records. The formula will be evaluated for each record, and if the result is not 0 , false , "" , NaN , [] , or #Error! the record will be included in the response. We recommend testing your formula in the Formula field UI before using it in your API request. If combined wit |
+| `maxRecords`            | number           | optional   | The maximum total number of records that will be returned in your requests. If this value is larger than pageSize (which is 100 by default), you may have to load multiple pages to reach this total. See the Pagination section below for more. |
+| `pageSize`              | number           | optional   | The number of records returned in each request. Must be less than or equal to 100. Default is 100. See the Pagination section below for more. |
+| `sort`                  | array of objects | optional   | A list of sort objects that specifies how the records will be ordered. Each sort object must have a field key specifying the name of the field to sort on, and an optional direction key that is either "asc" or "desc" . The default direction is "asc" . The sort parameter overrides the sorting of the v |
+| `view`                  | string           | optional   | The name or ID of a view in the Dot Records Data table. If set, only the records in that view will be returned. The records will be sorted according to the order of the view unless the sort parameter is included, which overrides that order. Fields hidden in this view will be returned in the results. |
+| `cellFormat`            | string           | optional   | The format that should be used for cell values. Supported values are: json : cells will be formatted as JSON, depending on the field type. string : cells will be formatted as user-facing strings, regardless of the field type. The timeZone and userLocale parameters are required when using string as t |
+| `timeZone`              | string           | optional   | The time zone that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `userLocale`            | string           | optional   | The user locale that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `returnFieldsByFieldId` | boolean          | optional   | An optional boolean value that lets you return field objects where the key is the field id. This defaults to false , which returns field objects where the key is the field name. |
+| `recordMetadata`        | array of strings | optional   | An optional field that, if includes commentCount , adds a commentCount read only property on each record returned. |
+
+---
+
+## Retrieve a Record
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/dot%20records%20data`
+
+To retrieve an existing record in Dot Records Data table, issue a GET request to the record endpoint.
+
+Any "empty" fields (e.g. "" , [] , or false ) in the record will not be returned.
+
+```bash
+curl https://api.airtable.com/v0/appEurfA8kXQE3slK/Dot%20Records%20Data/recL8FQe7krO5U6xs \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+---
+
+## Create Records
+
+**Endpoint:** `POST /v0/appEurfA8kXQE3slK/dot%20records%20data`
+
+To create new records, issue a POST request to the Dot Records Data endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have one key whose value is an inner object containing your record's cell values, keyed by either field name or field id.
+
+```bash
+curl -X POST https://api.airtable.com/v0/appEurfA8kXQE3slK/Dot%20Records%20Data \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "fields": {
+        "Album / Single Title": "L.P. Albums released in U.S.A."
+      }
+    },
+    {
+      "fields": {
+        "Release Label": "Dot DLP 3012",
+        "Album / Single Title": "Pat Boone",
+        "Date": "1956",
+        "Status": true,
+        "Collaborator": "Chaz"
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Update / Upsert Records
+
+**Endpoint:** `PATCH /v0/appEurfA8kXQE3slK/dot%20records%20data`
+
+To update Dot Records Data records, issue a request to the Dot Records Data endpoint. Table names and table IDs can be used interchangeably. Using table IDs means table name changes won't require modifying your API request code. A PATCH request will only update the fields included in the request. Fields not included in the request will be unchanged. A PUT request will perform a destructive update and clear all unincluded cell values.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have an id property representing the record ID and a fields property which contains all of your record's cell values by field name or field id for all of your record's cell values by field name.
+
+```bash
+curl -X PATCH https://api.airtable.com/v0/appEurfA8kXQE3slK/Dot%20Records%20Data \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "id": "recL8FQe7krO5U6xs",
+      "fields": {
+        "Album / Single Title": "L.P. Albums released in U.S.A."
+      }
+    },
+    {
+      "id": "recYcWPqfFS7YeATT",
+      "fields": {
+        "Release Label": "Dot DLP 3012",
+        "Album / Single Title": "Pat Boone",
+        "Date": "1956",
+        "Status": true,
+        "Collaborator": "Chaz"
+      }
+    },
+    {
+      "id": "rec7jilJrMd9zPxAp",
+      "fields": {
+        "Release Label": "Dot DLP 3030",
+        "Album / Single Title": "Howdy!",
+        "Date": "1957",
+        "Status": true,
+        "Collaborator": "Chaz"
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Delete Records
+
+**Endpoint:** `DELETE /v0/appEurfA8kXQE3slK/dot%20records%20data`
+
+To delete Dot Records Data records, issue a DELETE request to the Dot Records Data endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request should include a URL-encoded array of up to 10 record IDs to delete.
+
+```bash
+curl -X DELETE https://api.airtable.com/v0/appEurfA8kXQE3slK/Dot%20Records%20Data \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -G \
+  --data-urlencode 'records[]=recL8FQe7krO5U6xs' \
+  --data-urlencode 'records[]=recYcWPqfFS7YeATT'
+```
+

--- a/DOCS/AIRTABLE_API/legal-docs.md
+++ b/DOCS/AIRTABLE_API/legal-docs.md
@@ -1,0 +1,242 @@
+# Legal Docs
+
+**Table ID:** `tbl0JjCNEaGmFGAkx`  
+**Base ID:** `appEurfA8kXQE3slK`
+
+---
+
+## Fields
+
+| Field Name                     | Field ID            | Type                   | Description                                                                      |
+| ------------------------------ | ------------------- | ---------------------- | -------------------------------------------------------------------------------- |
+| Legal Document                 | `fldmoQzt8ffAPtWCV` | Text                   | A single line of text.                                                           |
+| Notes                          | `fldjruRCbq2rRn5b0` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| Link to Document(s)            | `fldLQRo1T8X4RGpj5` | URL                    | A valid URL (e.g. airtable.com or https://airtable.com/universe).                |
+| Related Legal Docs             | `fldTIZRdifmWsei2p` | Link to another record | Array of linked records IDs from the Legal Docs table.                           |
+| Document Type                  | `fldL0MpAt1r3OJfZN` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Contract Status                | `fldEwhRSpay7n4edv` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Effective Date                 | `fldTzSY2siUPNxRPy` | Date                   | UTC date, e.g. "2014-09-05".                                                     |
+| Expiration Date                | `fldimOj9fbSairsOp` | Date                   | UTC date, e.g. "2014-09-05".                                                     |
+| Territory                      | `fldoCSxk16H4F6bzz` | Text                   | A single line of text.                                                           |
+| Master Owner                   | `fldXUjQvuEbtzF2y6` | Link to another record | Array of linked records IDs from the Master Owners table.                        |
+| Artists                        | `fld589CVNN3Dz4LIo` | Link to another record | Array of linked records IDs from the Artists table.                              |
+| Linked Compositions            | `fldD2pmUU5QiXFHSx` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Publisher(s)                   | `fldE9rUE0HpFuoxGX` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Songwriter(s)                  | `fld1qPXmNU8VlgWOj` | Link to another record | Array of linked records IDs from the Songwriters table.                          |
+| Recordings                     | `fldPBENvLLuCsdN7g` | Link to another record | Array of linked records IDs from the Recordings table.                           |
+| Releases                       | `fldoyrjPJv0VJzsns` | Link to another record | Array of linked records IDs from the Releases table.                             |
+| From field: Related Legal Docs | `flddf50UzWyJzJA7G` | Link to another record | Array of linked records IDs from the Legal Docs table.                           |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/legal%20docs`
+
+To list records in Legal Docs , issue a GET request to the Legal Docs endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Returned records do not include any fields with "empty" values, e.g. "" , [] , or false .
+
+```bash
+curl "https://api.airtable.com/v0/appEurfA8kXQE3slK/Legal%20Docs?maxRecords=3&view=Grid%20view" \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+### Query Parameters
+
+| Parameter               | Type             | Required   | Description                                                                      |
+| ----------------------- | ---------------- | ---------- | -------------------------------------------------------------------------------- |
+| `fields`                | array of strings | optional   | Only data for fields whose names are in this list will be included in the result. If you don't need every field, you can use this parameter to reduce the amount of data transferred. For example, to only return data from Legal Document and Notes , send these two query parameters: fields%5B%5D=Legal%2 |
+| `filterByFormula`       | string           | optional   | A formula used to filter records. The formula will be evaluated for each record, and if the result is not 0 , false , "" , NaN , [] , or #Error! the record will be included in the response. We recommend testing your formula in the Formula field UI before using it in your API request. If combined wit |
+| `maxRecords`            | number           | optional   | The maximum total number of records that will be returned in your requests. If this value is larger than pageSize (which is 100 by default), you may have to load multiple pages to reach this total. See the Pagination section below for more. |
+| `pageSize`              | number           | optional   | The number of records returned in each request. Must be less than or equal to 100. Default is 100. See the Pagination section below for more. |
+| `sort`                  | array of objects | optional   | A list of sort objects that specifies how the records will be ordered. Each sort object must have a field key specifying the name of the field to sort on, and an optional direction key that is either "asc" or "desc" . The default direction is "asc" . The sort parameter overrides the sorting of the v |
+| `view`                  | string           | optional   | The name or ID of a view in the Legal Docs table. If set, only the records in that view will be returned. The records will be sorted according to the order of the view unless the sort parameter is included, which overrides that order. Fields hidden in this view will be returned in the results. To on |
+| `cellFormat`            | string           | optional   | The format that should be used for cell values. Supported values are: json : cells will be formatted as JSON, depending on the field type. string : cells will be formatted as user-facing strings, regardless of the field type. The timeZone and userLocale parameters are required when using string as t |
+| `timeZone`              | string           | optional   | The time zone that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `userLocale`            | string           | optional   | The user locale that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `returnFieldsByFieldId` | boolean          | optional   | An optional boolean value that lets you return field objects where the key is the field id. This defaults to false , which returns field objects where the key is the field name. |
+| `recordMetadata`        | array of strings | optional   | An optional field that, if includes commentCount , adds a commentCount read only property on each record returned. |
+
+---
+
+## Retrieve a Record
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/legal%20docs`
+
+To retrieve an existing record in Legal Docs table, issue a GET request to the record endpoint.
+
+Any "empty" fields (e.g. "" , [] , or false ) in the record will not be returned.
+
+```bash
+curl https://api.airtable.com/v0/appEurfA8kXQE3slK/Legal%20Docs/recUMZMcVMzwiu50I \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+---
+
+## Create Records
+
+**Endpoint:** `POST /v0/appEurfA8kXQE3slK/legal%20docs`
+
+To create new records, issue a POST request to the Legal Docs endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have one key whose value is an inner object containing your record's cell values, keyed by either field name or field id.
+
+```bash
+curl -X POST https://api.airtable.com/v0/appEurfA8kXQE3slK/Legal%20Docs \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "fields": {
+        "Legal Document": "Dot Records Notice of Termination",
+        "Notes": "This document affects recordings between 1954 and December 31, 1963. They were originally owned by Dot (Universal) and are now owned by PBGL.",
+        "Link to Document(s)": "https://app.box.com/s/8c56xlsviqeb9e99zsy7pe5lkyjrknva",
+        "Document Type": [
+          "Notice of Termination"
+        ],
+        "Contract Status": "Terminated",
+        "Master Owner": [
+          "recFsgtFh5ff9SxTo",
+          "recT0ecpuEpwlNIRj",
+          "recmbD0S2y6gdZY0M"
+        ],
+        "Artists": [
+          "recLWgt9qnlgDkkAo"
+        ]
+      }
+    },
+    {
+      "fields": {
+        "Legal Document": "Termination of Publishing Administration Agreement (Sweet On Top)",
+        "Link to Document(s)": "https://app.box.com/s/23vsfyhnnvs1af4slz2dxsfwgjlci08p",
+        "Document Type": [
+          "Notice of Termination"
+        ],
+        "Contract Status": "Active",
+        "Effective Date": "2024-08-01",
+        "Master Owner": [
+          "recmbD0S2y6gdZY0M"
+        ],
+        "Publisher(s)": [
+          "rec4gUR7stMFkj10q",
+          "recdo7hEep1rfVDCC",
+          "recpbxExDaBhGyWkS",
+          "recJQPGTBcdpMAwqB"
+        ],
+        "From field: Related Legal Docs": [
+          "recduGrUuXK8y9zsw",
+          "rec27paI1G3JkghDp"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Update / Upsert Records
+
+**Endpoint:** `PATCH /v0/appEurfA8kXQE3slK/legal%20docs`
+
+To update Legal Docs records, issue a request to the Legal Docs endpoint. Table names and table IDs can be used interchangeably. Using table IDs means table name changes won't require modifying your API request code. A PATCH request will only update the fields included in the request. Fields not included in the request will be unchanged. A PUT request will perform a destructive update and clear all unincluded cell values.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have an id property representing the record ID and a fields property which contains all of your record's cell values by field name or field id for all of your record's cell values by field name.
+
+```bash
+curl -X PATCH https://api.airtable.com/v0/appEurfA8kXQE3slK/Legal%20Docs \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "id": "recUMZMcVMzwiu50I",
+      "fields": {
+        "Legal Document": "Dot Records Notice of Termination",
+        "Notes": "This document affects recordings between 1954 and December 31, 1963. They were originally owned by Dot (Universal) and are now owned by PBGL.",
+        "Link to Document(s)": "https://app.box.com/s/8c56xlsviqeb9e99zsy7pe5lkyjrknva",
+        "Document Type": [
+          "Notice of Termination"
+        ],
+        "Contract Status": "Terminated",
+        "Master Owner": [
+          "recFsgtFh5ff9SxTo",
+          "recT0ecpuEpwlNIRj",
+          "recmbD0S2y6gdZY0M"
+        ],
+        "Artists": [
+          "recLWgt9qnlgDkkAo"
+        ]
+      }
+    },
+    {
+      "id": "recZsahORphdy8KdM",
+      "fields": {
+        "Legal Document": "Termination of Publishing Administration Agreement (Sweet On Top)",
+        "Link to Document(s)": "https://app.box.com/s/23vsfyhnnvs1af4slz2dxsfwgjlci08p",
+        "Document Type": [
+          "Notice of Termination"
+        ],
+        "Contract Status": "Active",
+        "Effective Date": "2024-08-01",
+        "Master Owner": [
+          "recmbD0S2y6gdZY0M"
+        ],
+        "Publisher(s)": [
+          "rec4gUR7stMFkj10q",
+          "recdo7hEep1rfVDCC",
+          "recpbxExDaBhGyWkS",
+          "recJQPGTBcdpMAwqB"
+        ],
+        "From field: Related Legal Docs": [
+          "recduGrUuXK8y9zsw",
+          "rec27paI1G3JkghDp"
+        ]
+      }
+    },
+    {
+      "id": "recduGrUuXK8y9zsw",
+      "fields": {
+        "Legal Document": "COOGA MUSIC CORP~SWEET ON TOP LOD (BMI) AUG 8 2022 Signed",
+        "Link to Document(s)": "https://app.box.com/s/9hf22s10pfq4xabogls0scdnl9mv5qjd",
+        "Related Legal Docs": [
+          "recZsahORphdy8KdM"
+        ],
+        "Document Type": [
+          "Publishing Agreement"
+        ],
+        "Contract Status": "Terminated",
+        "Effective Date": "2022-02-25",
+        "Expiration Date": "2024-08-01",
+        "Publisher(s)": [
+          "recJQPGTBcdpMAwqB",
+          "rec4gUR7stMFkj10q",
+          "recdo7hEep1rfVDCC"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Delete Records
+
+**Endpoint:** `DELETE /v0/appEurfA8kXQE3slK/legal%20docs`
+
+To delete Legal Docs records, issue a DELETE request to the Legal Docs endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request should include a URL-encoded array of up to 10 record IDs to delete.
+
+```bash
+curl -X DELETE https://api.airtable.com/v0/appEurfA8kXQE3slK/Legal%20Docs \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -G \
+  --data-urlencode 'records[]=recUMZMcVMzwiu50I' \
+  --data-urlencode 'records[]=recZsahORphdy8KdM'
+```
+

--- a/DOCS/AIRTABLE_API/master-owners.md
+++ b/DOCS/AIRTABLE_API/master-owners.md
@@ -1,0 +1,180 @@
+# Master Owners
+
+**Table ID:** `tblqfRCyEWjlfTMBd`  
+**Base ID:** `appEurfA8kXQE3slK`
+
+---
+
+## Fields
+
+| Field Name                                  | Field ID            | Type                   | Description                                                                      |
+| ------------------------------------------- | ------------------- | ---------------------- | -------------------------------------------------------------------------------- |
+| Full Name                                   | `fldtvwgRleoMxQbRJ` | Text                   | A single line of text.                                                           |
+| Notes                                       | `fldTM3fG4zoYmUeAR` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| Type                                        | `fldUlKL2bb6CYYVjb` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Related labels                              | `fldocX256KHFPNvak` | Link to another record | Array of linked records IDs from the Master Owners table.                        |
+| Owned Recordings                            | `fldxyKSwINUjwCSfK` | Link to another record | Array of linked records IDs from the Recordings table.                           |
+| Original releases                           | `fldBpxKhX21ESiiuE` | Link to another record | Array of linked records IDs from the Releases table.                             |
+| Website                                     | `fldRXDzueTV4Z1CYx` | URL                    | A valid URL (e.g. airtable.com or https://airtable.com/universe).                |
+| Email                                       | `fldlRtBTe6Sb4YPSj` | Text                   | A single line of text.                                                           |
+| Phone Number                                | `fld7bVTZM4uAHsp45` | Phone number           | A telephone number, e.g. "(415) 555-9876".                                       |
+| Address                                     | `fldBwpKJKtxKI0hfz` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| Fax                                         | `fld5hFOAoDW6w3H0g` | Text                   | A single line of text.                                                           |
+| [DON'T DELETE] Master Owner 2 in Recordings | `fld3eWa7SYrEN2HkL` | Link to another record | Array of linked records IDs from the Recordings table.                           |
+| [DON'T DELETE] Master Owner 3 in Recordings | `fld1Iq5MydRBkOktY` | Link to another record | Array of linked records IDs from the Recordings table.                           |
+| Releases                                    | `fldWAKqc4GPb7uesN` | Link to another record | Array of linked records IDs from the Releases table.                             |
+| Legal Docs                                  | `fldZxv4TMJuPZNWPH` | Link to another record | Array of linked records IDs from the Legal Docs table.                           |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/master%20owners`
+
+To list records in Master Owners , issue a GET request to the Master Owners endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Returned records do not include any fields with "empty" values, e.g. "" , [] , or false .
+
+```bash
+curl "https://api.airtable.com/v0/appEurfA8kXQE3slK/Master%20Owners?maxRecords=3&view=Default" \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+### Query Parameters
+
+| Parameter               | Type             | Required   | Description                                                                      |
+| ----------------------- | ---------------- | ---------- | -------------------------------------------------------------------------------- |
+| `fields`                | array of strings | optional   | Only data for fields whose names are in this list will be included in the result. If you don't need every field, you can use this parameter to reduce the amount of data transferred. For example, to only return data from Full Name and Notes , send these two query parameters: fields%5B%5D=Full%20Name& |
+| `filterByFormula`       | string           | optional   | A formula used to filter records. The formula will be evaluated for each record, and if the result is not 0 , false , "" , NaN , [] , or #Error! the record will be included in the response. We recommend testing your formula in the Formula field UI before using it in your API request. If combined wit |
+| `maxRecords`            | number           | optional   | The maximum total number of records that will be returned in your requests. If this value is larger than pageSize (which is 100 by default), you may have to load multiple pages to reach this total. See the Pagination section below for more. |
+| `pageSize`              | number           | optional   | The number of records returned in each request. Must be less than or equal to 100. Default is 100. See the Pagination section below for more. |
+| `sort`                  | array of objects | optional   | A list of sort objects that specifies how the records will be ordered. Each sort object must have a field key specifying the name of the field to sort on, and an optional direction key that is either "asc" or "desc" . The default direction is "asc" . The sort parameter overrides the sorting of the v |
+| `view`                  | string           | optional   | The name or ID of a view in the Master Owners table. If set, only the records in that view will be returned. The records will be sorted according to the order of the view unless the sort parameter is included, which overrides that order. Fields hidden in this view will be returned in the results. To |
+| `cellFormat`            | string           | optional   | The format that should be used for cell values. Supported values are: json : cells will be formatted as JSON, depending on the field type. string : cells will be formatted as user-facing strings, regardless of the field type. The timeZone and userLocale parameters are required when using string as t |
+| `timeZone`              | string           | optional   | The time zone that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `userLocale`            | string           | optional   | The user locale that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `returnFieldsByFieldId` | boolean          | optional   | An optional boolean value that lets you return field objects where the key is the field id. This defaults to false , which returns field objects where the key is the field name. |
+| `recordMetadata`        | array of strings | optional   | An optional field that, if includes commentCount , adds a commentCount read only property on each record returned. |
+
+---
+
+## Retrieve a Record
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/master%20owners`
+
+To retrieve an existing record in Master Owners table, issue a GET request to the record endpoint.
+
+Any "empty" fields (e.g. "" , [] , or false ) in the record will not be returned.
+
+```bash
+curl https://api.airtable.com/v0/appEurfA8kXQE3slK/Master%20Owners/recUDZHO1FfOxP3PO \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+---
+
+## Create Records
+
+**Endpoint:** `POST /v0/appEurfA8kXQE3slK/master%20owners`
+
+To create new records, issue a POST request to the Master Owners endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have one key whose value is an inner object containing your record's cell values, keyed by either field name or field id.
+
+```bash
+curl -X POST https://api.airtable.com/v0/appEurfA8kXQE3slK/Master%20Owners \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "fields": {
+        "Full Name": "Ace Records",
+        "Owned Recordings": [
+          "recgXQFMk5qIpqcuM"
+        ]
+      }
+    },
+    {
+      "fields": {
+        "Full Name": "ARC RECORDS INC",
+        "Releases": [
+          "rec14oSEG3QaqbHyf"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Update / Upsert Records
+
+**Endpoint:** `PATCH /v0/appEurfA8kXQE3slK/master%20owners`
+
+To update Master Owners records, issue a request to the Master Owners endpoint. Table names and table IDs can be used interchangeably. Using table IDs means table name changes won't require modifying your API request code. A PATCH request will only update the fields included in the request. Fields not included in the request will be unchanged. A PUT request will perform a destructive update and clear all unincluded cell values.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have an id property representing the record ID and a fields property which contains all of your record's cell values by field name or field id for all of your record's cell values by field name.
+
+```bash
+curl -X PATCH https://api.airtable.com/v0/appEurfA8kXQE3slK/Master%20Owners \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "id": "recUDZHO1FfOxP3PO",
+      "fields": {
+        "Full Name": "Ace Records",
+        "Owned Recordings": [
+          "recgXQFMk5qIpqcuM"
+        ]
+      }
+    },
+    {
+      "id": "rec1RuH3uNek9kaiG",
+      "fields": {
+        "Full Name": "ARC RECORDS INC",
+        "Releases": [
+          "rec14oSEG3QaqbHyf"
+        ]
+      }
+    },
+    {
+      "id": "rechinguIWIfITXBk",
+      "fields": {
+        "Full Name": "Ave Maria Records",
+        "Owned Recordings": [
+          "recMt2CZl3b7SCRLP"
+        ],
+        "Original releases": [
+          "recdVXyd29GuF23h8"
+        ],
+        "Releases": [
+          "recdVXyd29GuF23h8"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Delete Records
+
+**Endpoint:** `DELETE /v0/appEurfA8kXQE3slK/master%20owners`
+
+To delete Master Owners records, issue a DELETE request to the Master Owners endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request should include a URL-encoded array of up to 10 record IDs to delete.
+
+```bash
+curl -X DELETE https://api.airtable.com/v0/appEurfA8kXQE3slK/Master%20Owners \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -G \
+  --data-urlencode 'records[]=recUDZHO1FfOxP3PO' \
+  --data-urlencode 'records[]=rec1RuH3uNek9kaiG'
+```
+

--- a/DOCS/AIRTABLE_API/progress-report.md
+++ b/DOCS/AIRTABLE_API/progress-report.md
@@ -1,0 +1,178 @@
+# PROGRESS REPORT
+
+**Table ID:** `tblPBXgEXtDH6TaRR`  
+**Base ID:** `appEurfA8kXQE3slK`
+
+---
+
+## Fields
+
+| Field Name            | Field ID            | Type                   | Description                                                                      |
+| --------------------- | ------------------- | ---------------------- | -------------------------------------------------------------------------------- |
+| Release Title         | `fldFb7YFRUNKDKQdp` | Text                   | A single line of text.                                                           |
+| Release type          | `fldeIOemLOoixI0U5` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Artist                | `fldtNgc6KEbNgrgGg` | Text                   | A single line of text.                                                           |
+| PRIORITY              | `fldIQZFwVBKLhCbWC` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Status                | `fldKmbbiS5A8XK92K` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| NOTES                 | `fld7f2ziMrqMRAebl` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| Physical copy on hand | `fldlgVdq6Bf7gGOS2` | Checkbox               | This field is "true" when checked and otherwise empty.                           |
+| CBz Pub Research      | `flduOLHR5zgIYaNhk` | Checkbox               | This field is "true" when checked and otherwise empty.                           |
+| Splits Confirmed      | `fldcq2jB9wEcMCrZi` | Checkbox               | This field is "true" when checked and otherwise empty.                           |
+| Tagged                | `fldrCK2V7XjGvmfP6` | Checkbox               | This field is "true" when checked and otherwise empty.                           |
+| Lyric Sheets          | `fldLKpmuxWZ6Hxq4X` | Checkbox               | This field is "true" when checked and otherwise empty.                           |
+| Spreadsheet Verified  | `fld4rsw4q6tJoXM1L` | Checkbox               | This field is "true" when checked and otherwise empty.                           |
+| PBGL Approved         | `fldZbby1Q4esefLhr` | Checkbox               | This field is "true" when checked and otherwise empty.                           |
+| SoundExchange Onboard | `flduhK6psUxE5RyXi` | Checkbox               | This field is "true" when checked and otherwise empty.                           |
+| Missing Files         | `fldlxqWNDAXgVWgUt` | Text                   | A single line of text.                                                           |
+| Unreconciled Songs    | `fld8sYklhyeZnoAau` | Text                   | A single line of text.                                                           |
+| SOP Delivery          | `fldiqU9Z7MNv1wcFt` | Checkbox               | This field is "true" when checked and otherwise empty.                           |
+| Releases              | `fldYG5yQVaoJrH8LE` | Link to another record | Array of linked records IDs from the Releases table.                             |
+| UPC (from Releases)   | `fldqDkEctL0Hdjyvg` | Lookup                 | Array of UPC fields in linked Releases records.                                  |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/progress%20report`
+
+To list records in PROGRESS REPORT , issue a GET request to the PROGRESS REPORT endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Returned records do not include any fields with "empty" values, e.g. "" , [] , or false .
+
+```bash
+curl "https://api.airtable.com/v0/appEurfA8kXQE3slK/PROGRESS%20REPORT?maxRecords=3&view=Default" \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+### Query Parameters
+
+| Parameter               | Type             | Required   | Description                                                                      |
+| ----------------------- | ---------------- | ---------- | -------------------------------------------------------------------------------- |
+| `fields`                | array of strings | optional   | Only data for fields whose names are in this list will be included in the result. If you don't need every field, you can use this parameter to reduce the amount of data transferred. For example, to only return data from Release Title and Release type , send these two query parameters: fields%5B%5D=R |
+| `filterByFormula`       | string           | optional   | A formula used to filter records. The formula will be evaluated for each record, and if the result is not 0 , false , "" , NaN , [] , or #Error! the record will be included in the response. We recommend testing your formula in the Formula field UI before using it in your API request. If combined wit |
+| `maxRecords`            | number           | optional   | The maximum total number of records that will be returned in your requests. If this value is larger than pageSize (which is 100 by default), you may have to load multiple pages to reach this total. See the Pagination section below for more. |
+| `pageSize`              | number           | optional   | The number of records returned in each request. Must be less than or equal to 100. Default is 100. See the Pagination section below for more. |
+| `sort`                  | array of objects | optional   | A list of sort objects that specifies how the records will be ordered. Each sort object must have a field key specifying the name of the field to sort on, and an optional direction key that is either "asc" or "desc" . The default direction is "asc" . The sort parameter overrides the sorting of the v |
+| `view`                  | string           | optional   | The name or ID of a view in the PROGRESS REPORT table. If set, only the records in that view will be returned. The records will be sorted according to the order of the view unless the sort parameter is included, which overrides that order. Fields hidden in this view will be returned in the results. |
+| `cellFormat`            | string           | optional   | The format that should be used for cell values. Supported values are: json : cells will be formatted as JSON, depending on the field type. string : cells will be formatted as user-facing strings, regardless of the field type. The timeZone and userLocale parameters are required when using string as t |
+| `timeZone`              | string           | optional   | The time zone that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `userLocale`            | string           | optional   | The user locale that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `returnFieldsByFieldId` | boolean          | optional   | An optional boolean value that lets you return field objects where the key is the field id. This defaults to false , which returns field objects where the key is the field name. |
+| `recordMetadata`        | array of strings | optional   | An optional field that, if includes commentCount , adds a commentCount read only property on each record returned. |
+
+---
+
+## Retrieve a Record
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/progress%20report`
+
+To retrieve an existing record in PROGRESS REPORT table, issue a GET request to the record endpoint.
+
+Any "empty" fields (e.g. "" , [] , or false ) in the record will not be returned.
+
+```bash
+curl https://api.airtable.com/v0/appEurfA8kXQE3slK/PROGRESS%20REPORT/recFGa7MniT0S2buD \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+---
+
+## Create Records
+
+**Endpoint:** `POST /v0/appEurfA8kXQE3slK/progress%20report`
+
+To create new records, issue a POST request to the PROGRESS REPORT endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have one key whose value is an inner object containing your record's cell values, keyed by either field name or field id.
+
+```bash
+curl -X POST https://api.airtable.com/v0/appEurfA8kXQE3slK/PROGRESS%20REPORT \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "fields": {
+        "Release Title": "\"Pat\" On Mike",
+        "Release type": "EP",
+        "Artist": "Pat Boone",
+        "SoundExchange Onboard": true
+      }
+    },
+    {
+      "fields": {
+        "Release Title": "A Foggy Day (Live On The Pat Boone Chevy Showroom, November 7, 1957)",
+        "Release type": "Single",
+        "Artist": "Pat Boone",
+        "SoundExchange Onboard": true
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Update / Upsert Records
+
+**Endpoint:** `PATCH /v0/appEurfA8kXQE3slK/progress%20report`
+
+To update PROGRESS REPORT records, issue a request to the PROGRESS REPORT endpoint. Table names and table IDs can be used interchangeably. Using table IDs means table name changes won't require modifying your API request code. A PATCH request will only update the fields included in the request. Fields not included in the request will be unchanged. A PUT request will perform a destructive update and clear all unincluded cell values.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have an id property representing the record ID and a fields property which contains all of your record's cell values by field name or field id for all of your record's cell values by field name.
+
+```bash
+curl -X PATCH https://api.airtable.com/v0/appEurfA8kXQE3slK/PROGRESS%20REPORT \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "id": "recFGa7MniT0S2buD",
+      "fields": {
+        "Release Title": "\"Pat\" On Mike",
+        "Release type": "EP",
+        "Artist": "Pat Boone",
+        "SoundExchange Onboard": true
+      }
+    },
+    {
+      "id": "recvP68aGHzyU2zc9",
+      "fields": {
+        "Release Title": "A Foggy Day (Live On The Pat Boone Chevy Showroom, November 7, 1957)",
+        "Release type": "Single",
+        "Artist": "Pat Boone",
+        "SoundExchange Onboard": true
+      }
+    },
+    {
+      "id": "recLFahsaozJh3jky",
+      "fields": {
+        "Release Title": "Angel Talk",
+        "Release type": "EP",
+        "Artist": "Pat Boone",
+        "SoundExchange Onboard": true
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Delete Records
+
+**Endpoint:** `DELETE /v0/appEurfA8kXQE3slK/progress%20report`
+
+To delete PROGRESS REPORT records, issue a DELETE request to the PROGRESS REPORT endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request should include a URL-encoded array of up to 10 record IDs to delete.
+
+```bash
+curl -X DELETE https://api.airtable.com/v0/appEurfA8kXQE3slK/PROGRESS%20REPORT \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -G \
+  --data-urlencode 'records[]=recFGa7MniT0S2buD' \
+  --data-urlencode 'records[]=recvP68aGHzyU2zc9'
+```
+

--- a/DOCS/AIRTABLE_API/publishers.md
+++ b/DOCS/AIRTABLE_API/publishers.md
@@ -1,0 +1,282 @@
+# Publishers
+
+**Table ID:** `tbl6TNKQRPfY3hXZ2`  
+**Base ID:** `appEurfA8kXQE3slK`
+
+---
+
+## Fields
+
+| Field Name                                                    | Field ID            | Type                   | Description                                                                      |
+| ------------------------------------------------------------- | ------------------- | ---------------------- | -------------------------------------------------------------------------------- |
+| Publisher Name as listed in PRO                               | `fldoZYGr25EDkuhsK` | Text                   | A single line of text.                                                           |
+| Admin only                                                    | `fldENRgphuN5e20wm` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| IPI/CAE Number                                                | `fldShVinPtEIat3OK` | Text                   | A single line of text.                                                           |
+| Notes                                                         | `fldi4EipsbtQHbk8z` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| PRO Affiliation                                               | `fldKl7mWFTOeX4Pd5` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Name, PRO, & IPI verified                                     | `fldLES73qEcqgLD7R` | Checkbox               | This field is "true" when checked and otherwise empty.                           |
+| Original Pub. Compositions                                    | `fldun7E4qgE0odL9Q` | Link to another record | Array of linked records IDs from the Compositions table. Because this field is configured to show records in reversed order, the order of records in the app will be reversed compared to what you see here. |
+| Admin Pub. Compositions                                       | `fldpqaDDnpqZhO1Wf` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Email                                                         | `fld8DLloLv756cSRI` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| Phone                                                         | `fldgrxA4tgnHFotDO` | Phone number           | A telephone number, e.g. "(415) 555-9876".                                       |
+| Address                                                       | `fld5qxq6UWur7PuDN` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| Website                                                       | `fldTcuR6h9QK31atX` | URL                    | A valid URL (e.g. airtable.com or https://airtable.com/universe).                |
+| Fax                                                           | `fldCb5JpKNMJWkWS8` | Phone number           | A telephone number, e.g. "(415) 555-9876".                                       |
+| Songwriters                                                   | `fldP7iqjXfkQMvTdS` | Link to another record | Array of linked records IDs from the Songwriters table.                          |
+| Controlled by HFA                                             | `fldk4CQtVpHSqHsbz` | Checkbox               | This field is "true" when checked and otherwise empty.                           |
+| Controlled                                                    | `fldZo181nZRPqVAea` | Checkbox               | This field is "true" when checked and otherwise empty.                           |
+| In Care Of                                                    | `fldPx8Rrlljp0Uw94` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Administered Pubs                                             | `fldMTRizR1S5wOPbx` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Legal Docs                                                    | `fldFFEnrBSdCtHfvZ` | Link to another record | Array of linked records IDs from the Legal Docs table.                           |
+| Compositions 2                                                | `fld0F4H8p2o1lB0ke` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 2 copy copy copy copy copy                       | `fldvWu5Zds1bLlEO1` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 2 copy copy copy copy copy copy                  | `flddZoNgL6NCjVjkH` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 2 copy copy copy copy copy copy 2                | `fldopFt17eRVqNEHt` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 3                                                | `fldulVp0Sqlkd6GBN` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 4                                                | `fldmzdnUPayU3lz46` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 4 copy                                           | `fldzDHjoJOTEZvRvH` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 5                                                | `fldQMOiMTNTkqXywy` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 7                                                | `fldYb4g2nJF3rV5BM` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 8                                                | `fld8GPDIimAF88X7c` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 9                                                | `fld9igP7QmFkf35t2` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 4 copy copy                                      | `fldHbYON5zGkawaMs` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 4 copy copy copy                                 | `fldtVnbpMMEJZ35yo` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| [DON'T DELETE] Songwriter 1 Admin Pub. 1                      | `fldglzFhOjv7rHf1w` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| [DON'T DELETE] Songwriter 1 Admin Pub. 2                      | `fldIh4H7HEXy2F1S8` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| [DON'T DELETE] Songwriter 4 Admin. Pub                        | `fldYZazj3OrmsHCju` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 12                                               | `fldWzqRIJSbaJ5tiH` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 13                                               | `fld8gnu3E8nknQGC9` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 14                                               | `fldxZMcYsTAOH14Le` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 15                                               | `fldcdua8is6O6GlDj` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Songwriters copy                                              | `fldVVxtUF3rpiIfhn` | Text                   | A single line of text.                                                           |
+| Compositions 4 copy copy copy 2                               | `fld6PQDHfOViROIB8` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| [DON'T DELETE] Songwriter 1 Admin Pub. 2 copy                 | `fldBIQFiPxnxQjPxk` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions                                                  | `fldlrC144iV4zNWG2` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 6                                                | `fldMaAcUWcnGGEAAb` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 9 copy                                           | `fldQcDWvLacFwRjAk` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 9 copy copy                                      | `fldh39rBujJopq54w` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 2 copy copy copy copy copy copy copy             | `fldtfJlg25TNPyoPf` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 2 copy copy copy copy copy copy copy copy        | `fldo5yVC0DYzqFwZA` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 4 copy copy 2                                    | `fldorfBeI9MZqIKYz` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 13 copy                                          | `fldGXrBxQvSRLZTqo` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 6 copy                                           | `fldxqdoYdAs7Ht9dL` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 12 copy                                          | `fldOScZlbNc5cXi6M` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 3 copy                                           | `fldBix0171x0MtAfd` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 3 copy 2                                         | `fldgYVVoJVNQxxqyf` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 10                                               | `fldDFFPVmNC3Q5vX5` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 3 copy copy                                      | `fld65HT5Zb7zuyaBF` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 2 copy copy copy copy copy copy 2 copy           | `fldVgM6MIhgJql8NR` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 2 copy copy copy copy copy copy 2 copy 2         | `fldnn6XBpR8462zmY` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 9 copy 2                                         | `fldchgqpPmQDw3WYe` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 2 copy copy copy copy copy copy copy 2           | `fldnqV8YpOcLGNuep` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 2 copy copy copy copy copy copy copy copy 2      | `fldibZfUCXCpU5mMr` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 2 copy copy copy copy copy copy copy copy 3      | `fldi9rNbK3V1Sov1o` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 2 copy copy copy copy copy copy copy copy copy   | `fldSawzonAqUN5W5e` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 2 copy copy copy copy copy copy copy copy copy 2 | `fldFdnFv9OX1GYYfu` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 11                                               | `fldvEiJC2RS5RCrdu` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 16                                               | `fldvbx39TMF5UjP5I` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 17                                               | `fldomW1cs4V11B8dp` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 18                                               | `fldi1afN1x6zHRkt1` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Recordings                                                    | `fldvpO7nfEravR9Oe` | Text                   | A single line of text.                                                           |
+| Compositions 3 copy 3                                         | `flde9EV6H61CVoTq9` | Text                   | A single line of text.                                                           |
+| Compositions 4 copy copy copy copy                            | `fldHVrEwSKbAOQAc5` | Text                   | A single line of text.                                                           |
+| Compositions 4 copy copy copy copy 2                          | `fldTfzXhxdN9hCR7j` | Text                   | A single line of text.                                                           |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/publishers`
+
+To list records in Publishers , issue a GET request to the Publishers endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Returned records do not include any fields with "empty" values, e.g. "" , [] , or false .
+
+```bash
+curl "https://api.airtable.com/v0/appEurfA8kXQE3slK/Publishers?maxRecords=3&view=Default" \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+### Query Parameters
+
+| Parameter               | Type             | Required   | Description                                                                      |
+| ----------------------- | ---------------- | ---------- | -------------------------------------------------------------------------------- |
+| `fields`                | array of strings | optional   | Only data for fields whose names are in this list will be included in the result. If you don't need every field, you can use this parameter to reduce the amount of data transferred. For example, to only return data from Publisher Name as listed in PRO and Admin only , send these two query parameters |
+| `filterByFormula`       | string           | optional   | A formula used to filter records. The formula will be evaluated for each record, and if the result is not 0 , false , "" , NaN , [] , or #Error! the record will be included in the response. We recommend testing your formula in the Formula field UI before using it in your API request. If combined wit |
+| `maxRecords`            | number           | optional   | The maximum total number of records that will be returned in your requests. If this value is larger than pageSize (which is 100 by default), you may have to load multiple pages to reach this total. See the Pagination section below for more. |
+| `pageSize`              | number           | optional   | The number of records returned in each request. Must be less than or equal to 100. Default is 100. See the Pagination section below for more. |
+| `sort`                  | array of objects | optional   | A list of sort objects that specifies how the records will be ordered. Each sort object must have a field key specifying the name of the field to sort on, and an optional direction key that is either "asc" or "desc" . The default direction is "asc" . The sort parameter overrides the sorting of the v |
+| `view`                  | string           | optional   | The name or ID of a view in the Publishers table. If set, only the records in that view will be returned. The records will be sorted according to the order of the view unless the sort parameter is included, which overrides that order. Fields hidden in this view will be returned in the results. To on |
+| `cellFormat`            | string           | optional   | The format that should be used for cell values. Supported values are: json : cells will be formatted as JSON, depending on the field type. string : cells will be formatted as user-facing strings, regardless of the field type. The timeZone and userLocale parameters are required when using string as t |
+| `timeZone`              | string           | optional   | The time zone that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `userLocale`            | string           | optional   | The user locale that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `returnFieldsByFieldId` | boolean          | optional   | An optional boolean value that lets you return field objects where the key is the field id. This defaults to false , which returns field objects where the key is the field name. |
+| `recordMetadata`        | array of strings | optional   | An optional field that, if includes commentCount , adds a commentCount read only property on each record returned. |
+
+---
+
+## Retrieve a Record
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/publishers`
+
+To retrieve an existing record in Publishers table, issue a GET request to the record endpoint.
+
+Any "empty" fields (e.g. "" , [] , or false ) in the record will not be returned.
+
+```bash
+curl https://api.airtable.com/v0/appEurfA8kXQE3slK/Publishers/recpi95K1opi5lqgt \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+---
+
+## Create Records
+
+**Endpoint:** `POST /v0/appEurfA8kXQE3slK/publishers`
+
+To create new records, issue a POST request to the Publishers endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have one key whose value is an inner object containing your record's cell values, keyed by either field name or field id.
+
+```bash
+curl -X POST https://api.airtable.com/v0/appEurfA8kXQE3slK/Publishers \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "fields": {
+        "Publisher Name as listed in PRO": "100"
+      }
+    },
+    {
+      "fields": {
+        "Publisher Name as listed in PRO": "A. SCHROEDER INTERNATIONAL, LLC",
+        "Admin only": "✅",
+        "IPI/CAE Number": "00075129671",
+        "Admin Pub. Compositions": [
+          "recQwG1KX4yL8AeP0",
+          "rec18dF6m3sSiYqj2"
+        ],
+        "Email": "Aschroederinternational@gmail.com",
+        "Address": "A. Schroeder International, LLC\n297 Kinderkamack Road, Ste. 141\nOradell, NJ 07649",
+        "Songwriters": [
+          "recmgOMZIeRB9xJsi",
+          "recHvUMYGdxLrQV2o"
+        ],
+        "Administered Pubs": [
+          "recgOuK4DdHCNtKJx",
+          "rec7vdrgqnA5Yn5Hk"
+        ],
+        "[DON'\''T DELETE] Songwriter 1 Admin Pub. 1": [
+          "recQwG1KX4yL8AeP0"
+        ],
+        "Compositions 12": [
+          "recQwG1KX4yL8AeP0",
+          "rec18dF6m3sSiYqj2"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Update / Upsert Records
+
+**Endpoint:** `PATCH /v0/appEurfA8kXQE3slK/publishers`
+
+To update Publishers records, issue a request to the Publishers endpoint. Table names and table IDs can be used interchangeably. Using table IDs means table name changes won't require modifying your API request code. A PATCH request will only update the fields included in the request. Fields not included in the request will be unchanged. A PUT request will perform a destructive update and clear all unincluded cell values.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have an id property representing the record ID and a fields property which contains all of your record's cell values by field name or field id for all of your record's cell values by field name.
+
+```bash
+curl -X PATCH https://api.airtable.com/v0/appEurfA8kXQE3slK/Publishers \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "id": "recpi95K1opi5lqgt",
+      "fields": {
+        "Publisher Name as listed in PRO": "100"
+      }
+    },
+    {
+      "id": "reczxcD7XUSc2A45u",
+      "fields": {
+        "Publisher Name as listed in PRO": "A. SCHROEDER INTERNATIONAL, LLC",
+        "Admin only": "✅",
+        "IPI/CAE Number": "00075129671",
+        "Admin Pub. Compositions": [
+          "recQwG1KX4yL8AeP0",
+          "rec18dF6m3sSiYqj2"
+        ],
+        "Email": "Aschroederinternational@gmail.com",
+        "Address": "A. Schroeder International, LLC\n297 Kinderkamack Road, Ste. 141\nOradell, NJ 07649",
+        "Songwriters": [
+          "recmgOMZIeRB9xJsi",
+          "recHvUMYGdxLrQV2o"
+        ],
+        "Administered Pubs": [
+          "recgOuK4DdHCNtKJx",
+          "rec7vdrgqnA5Yn5Hk"
+        ],
+        "[DON'\''T DELETE] Songwriter 1 Admin Pub. 1": [
+          "recQwG1KX4yL8AeP0"
+        ],
+        "Compositions 12": [
+          "recQwG1KX4yL8AeP0",
+          "rec18dF6m3sSiYqj2"
+        ]
+      }
+    },
+    {
+      "id": "recA32cWs4hdKwuMr",
+      "fields": {
+        "Publisher Name as listed in PRO": "ABG ELVIS SONGS",
+        "Admin only": "🚫",
+        "IPI/CAE Number": "00736318242",
+        "PRO Affiliation": "BMI",
+        "Original Pub. Compositions": [
+          "rec1n2RecGxx85R7h",
+          "recMqmf641xTgJGi2",
+          "recGQF5mNpzcQS53y",
+          "recmRqDKz1eng6tju",
+          "recfSDlxXQLnpmyIv"
+        ],
+        "Songwriters": [
+          "recbZAt5iYwaAQ0vf"
+        ],
+        "In Care Of": [
+          "reca6gTTUwY0d38Xs"
+        ],
+        "Compositions 4": [
+          "rec1n2RecGxx85R7h"
+        ],
+        "Songwriters copy": "ROGERS  SMOKEY  "
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Delete Records
+
+**Endpoint:** `DELETE /v0/appEurfA8kXQE3slK/publishers`
+
+To delete Publishers records, issue a DELETE request to the Publishers endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request should include a URL-encoded array of up to 10 record IDs to delete.
+
+```bash
+curl -X DELETE https://api.airtable.com/v0/appEurfA8kXQE3slK/Publishers \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -G \
+  --data-urlencode 'records[]=recpi95K1opi5lqgt' \
+  --data-urlencode 'records[]=reczxcD7XUSc2A45u'
+```
+

--- a/DOCS/AIRTABLE_API/recordings.md
+++ b/DOCS/AIRTABLE_API/recordings.md
@@ -1,0 +1,621 @@
+# Recordings
+
+**Table ID:** `tblESvQQmOBbEXAH0`  
+**Base ID:** `appEurfA8kXQE3slK`
+
+---
+
+## Fields
+
+| Field Name                                                                 | Field ID            | Type                   | Description                                                                      |
+| -------------------------------------------------------------------------- | ------------------- | ---------------------- | -------------------------------------------------------------------------------- |
+| Title of Recording                                                         | `fldFslc4FKUDcfuk6` | Text                   | A single line of text.                                                           |
+| ISRC                                                                       | `fldNDD3nkxYymArNx` | Text                   | A single line of text.                                                           |
+| Missing songwriter on Spotify                                              | `fldRu6itZWVfd6XF9` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| All Releases                                                               | `fld57hhrA0PBM88o6` | Link to another record | Array of linked records IDs from the Releases table. Because this field is configured to show records in reversed order, the order of records in the app will be reversed compared to what you see here. |
+| Producer                                                                   | `fldOjjRaAHh1Aq557` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| All Songwriters (from Compositions)                                        | `fldiDU0dYFZvCXTcK` | Lookup                 | Array of All Songwriters fields in linked Compositions records.                  |
+| Compositions                                                               | `fldEAl8K8Sn0gvC98` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Master Owner 1                                                             | `fldMKw9veaxGqmWJy` | Link to another record | Array of linked records IDs from the Master Owners table.                        |
+| Master 1 Ownership                                                         | `fldh8WlYjYZiOLvJp` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Master Owner 2                                                             | `fldtEeYpvscGJUiCf` | Link to another record | Array of linked records IDs from the Master Owners table.                        |
+| Master 2 Ownership                                                         | `fldaULVlFMeGcBolS` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Spotify                                                                    | `fldPGiI1VFfdgZ0g3` | URL                    | A valid URL (e.g. airtable.com or https://airtable.com/universe).                |
+| REGISTRATION PROJECT (SOUNDEXCHANGE) 3                                     | `fldvX8g1YQ40aEtW4` | Link to another record | Array of linked records IDs from the REGISTRATION PROJECT (SOUNDEXCHANGE) table. |
+| Notes                                                                      | `fldQhFmxq7UKipROI` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| PBGL Owned                                                                 | `fldtZw9RzXJesBdJa` | Checkbox               | This field is "true" when checked and otherwise empty.                           |
+| SX (Rights Owner) (from REGISTRATION PROJECT (SOUNDEXCHANGE) 3)            | `fldeC3JotTgNKVsnn` | Lookup                 | Array of SX (Rights Owner) fields in linked REGISTRATION PROJECT (SOUNDEXCHANGE) records. |
+| SX (Artist) (from REGISTRATION PROJECT (SOUNDEXCHANGE) 3)                  | `fldgeSBWuvxlwenhH` | Lookup                 | Array of SX (Artist) fields in linked REGISTRATION PROJECT (SOUNDEXCHANGE) records. |
+| Distributed (from All Releases)                                            | `fldKiC3WFIx6nTkdl` | Lookup                 | Array of Distributed fields in linked Releases records.                          |
+| Primary Artist                                                             | `fld9vMhhhV6aAZPZP` | Link to another record | Array of linked records IDs from the Artists table.                              |
+| Featured Artist                                                            | `fldr6WmY3lmlfnTrb` | Link to another record | Array of linked records IDs from the Artists table.                              |
+| Master Owner 3                                                             | `fldEw8iScPnOFWTx0` | Link to another record | Array of linked records IDs from the Master Owners table.                        |
+| Master 3 Ownership                                                         | `fldjWbcozdEZOQkPU` | Percent                | Decimal number representing a percentage value. For example, the underlying cell value for 12.3% is 0.123. This field only allows positive numbers. |
+| Original Release                                                           | `fldV2X7dziu3HDfw8` | Link to another record | Array of linked records IDs from the Releases table.                             |
+| Master                                                                     | `fldxPAO3UZMI4QJal` | URL                    | A valid URL (e.g. airtable.com or https://airtable.com/universe).                |
+| Date of original Release                                                   | `fldbDhB8zzWzv8zIu` | Date                   | UTC date, e.g. "2014-09-05".                                                     |
+| Original recording title                                                   | `fldM5OsIrFiwyAUmP` | Text                   | A single line of text.                                                           |
+| Tempo Tag                                                                  | `fldBQ2uBIgfrvGO4g` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Mood Tag                                                                   | `fldGLPgeMuyCdFVI8` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Genre Tag                                                                  | `fldh4NuUtNapRJFUL` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Vocal Tag                                                                  | `flduQlucxqef6NlbK` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Instruments Tag                                                            | `fldfoMMkxh7IWfuW6` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Lyrical Theme Tag                                                          | `fldd0VUazaZ0umpSv` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Duration                                                                   | `fldcILmBh0XXuJCPs` | Duration               | An integer representing number of seconds. This field allows negative and positive numbers. |
+| DISCO                                                                      | `fldaeSYMSXiBd6yKe` | URL                    | A valid URL (e.g. airtable.com or https://airtable.com/universe).                |
+| UPC (from Releases)                                                        | `fldJL8W8wi9PgnRmG` | Lookup                 | Array of UPC fields in linked Releases records.                                  |
+| BPM                                                                        | `fldhfKrj6VzUWwzkb` | Number                 | A decimal number showing 1 decimal digit. This field only allows positive numbers. |
+| Apple Music                                                                | `fldpjXyMfeCDz0sDj` | URL                    | A valid URL (e.g. airtable.com or https://airtable.com/universe).                |
+| YouTube Music                                                              | `fldQRVCKtiQmHASbO` | URL                    | A valid URL (e.g. airtable.com or https://airtable.com/universe).                |
+| Soundcloud                                                                 | `fldSgqIszkWHqLiHy` | URL                    | A valid URL (e.g. airtable.com or https://airtable.com/universe).                |
+| Amazon Music                                                               | `fldY1Mm5szTZhg7Dp` | URL                    | A valid URL (e.g. airtable.com or https://airtable.com/universe).                |
+| Released (from All Releases)                                               | `fldB3jbtTOcXKSiTo` | Lookup                 | Array of Released fields in linked Releases records.                             |
+| Original release label (from Original release)                             | `fldboU3YZUpCCcwOK` | Lookup                 | Array of Original release label fields in linked Releases records.               |
+| Era                                                                        | `fldMznuTwRCIKPhEl` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Ready for Sync                                                             | `fld6XX8N0G5WLM2Pz` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Lyric Sheet                                                                | `fld0vvx3V1uScenIn` | URL                    | A valid URL (e.g. airtable.com or https://airtable.com/universe).                |
+| Type Tag                                                                   | `fldrjwgYHIbj2mkw9` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Current release label (from Original Release)                              | `fldCDfGQPzGHEtpsM` | Lookup                 | Array of Current release label fields in linked Releases records.                |
+| Recording year                                                             | `fldjJOfSCUpvryUwF` | Text                   | A single line of text.                                                           |
+| Status                                                                     | `fldj3fMbU5zOZgyf3` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Priority                                                                   | `fldm7nqe1sTAoR2Pi` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Verified Info (from Compositions)                                          | `flddLlV4VjmxZafUl` | Lookup                 | Array of Verified Info fields in linked Compositions records.                    |
+| Notes (from Compositions)                                                  | `fldJyzFef2mf0oBLY` | Lookup                 | Array of Notes fields in linked Compositions records.                            |
+| Original PD Work Title (from Compositions)                                 | `fldFNG8EdKA6ycmxP` | Lookup                 | Array of Original PD Work Title fields in linked Compositions records.           |
+| PD Work Status (from Compositions)                                         | `fldQzYc2ncCXqOGza` | Lookup                 | Array of PD Work Status fields in linked Compositions records.                   |
+| Production Title (from Compositions)                                       | `fldQwwHhLPBnqaiu6` | Lookup                 | Array of Production Title fields in linked Compositions records.                 |
+| Intended Purpose (from Compositions)                                       | `fldtYhu7ttbdaOhHg` | Lookup                 | Array of Intended Purpose fields in linked Compositions records.                 |
+| Date of First Use (from Compositions)                                      | `fldvoDRJBnjxhNVfN` | Lookup                 | Array of Date of First Use fields in linked Compositions records.                |
+| ISWC (from Compositions)                                                   | `fldu2832uigj0Cj7b` | Lookup                 | Array of ISWC fields in linked Compositions records.                             |
+| Published by PBGL                                                          | `fldRUN9gqcFDqezp8` | Lookup                 | Array of Controlled fields in linked Compositions records.                       |
+| All Admin Publishers (from Compositions)                                   | `fldAsjwXRXEiylltc` | Lookup                 | Array of All Admin Publishers fields in linked Compositions records.             |
+| All Original Publishers (from Compositions)                                | `fldzaPBXlUCId1Hvt` | Lookup                 | Array of All Original Publishers fields in linked Compositions records.          |
+| Uncredited PD Writers (from Compositions)                                  | `fld1GGnSFCFPgh8hC` | Lookup                 | Array of Uncredited PD Writers fields in linked Compositions records.            |
+| Song title in PRO                                                          | `fldVgLNtwRAZtArrg` | Lookup                 | Array of Song Title In PRO fields in linked Compositions records.                |
+| All Sub-Publishers (from Compositions)                                     | `fldU0n8US1A880O4P` | Lookup                 | Array of All Sub-Publishers fields in linked Compositions records.               |
+| Songwriter 1                                                               | `fldCA6dYLRDR7xPnb` | Lookup                 | Array of Songwriter 1 fields in linked Compositions records.                     |
+| Songwriter 1 Share                                                         | `fldjvmcxvO5hX2UKf` | Lookup                 | Array of Songwriter 1 Share fields in linked Compositions records.               |
+| Songwriter 1 Original Pub 1                                                | `fldRhipRn4M1aG4Fx` | Lookup                 | Array of Songwriter 1 Original Pub 1 fields in linked Compositions records.      |
+| Songwriter 1 Admin Pub 1 (from Compositions)                               | `fldcsfTSZUtnoQ90X` | Lookup                 | Array of Songwriter 1 Admin Pub 1 fields in linked Compositions records.         |
+| REGISTRATION PROJECT (SOUNDEXCHANGE) 2                                     | `fldQMrMMAmwti7Ggz` | Text                   | A single line of text.                                                           |
+| Compositions 2                                                             | `fld3gjnOrMPcFZalU` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 3                                                             | `fldn4r74Eub5FushA` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Songwriter 4 Admin Pub. 1 (from Compositions 3)                            | `fldONSv35u6Jmbi3i` | Lookup                 | Array of Songwriter 4 Admin Pub. 1 fields in linked Compositions records.        |
+| Songwriter 4 Original Pub. 1 Share (from Compositions 3)                   | `fldblG1ehtiMx09z5` | Lookup                 | Array of Songwriter 4 Original Pub. 1 Share fields in linked Compositions records. |
+| Songwriter 4 Original Pub. 1 (from Compositions 3)                         | `fld2aXCS0bGXIG3IZ` | Lookup                 | Array of Songwriter 4 Original Pub. 1 fields in linked Compositions records.     |
+| Songwriter 4 Ownership (from Compositions 3)                               | `fld3jJgddbKznn9oW` | Lookup                 | Array of Songwriter 4 Ownership fields in linked Compositions records.           |
+| Songwriter 4 (from Compositions 3)                                         | `fld5aNXIayXgUayqd` | Lookup                 | Array of Songwriter 4 fields in linked Compositions records.                     |
+| Songwriter 3 Admin Pub. 2 (from Compositions 3)                            | `fld2cKaDMiJAyy86P` | Lookup                 | Array of Songwriter 3 Admin Pub. 2 fields in linked Compositions records.        |
+| Songwriter 3 Original Pub. 2 Share (from Compositions 3)                   | `fld2VAMMcA8Wvru9j` | Lookup                 | Array of Songwriter 3 Original Pub. 2 Share fields in linked Compositions records. |
+| Songwriter 3 Original Pub. 2 (from Compositions 3)                         | `fld53jdtYFooQLKkU` | Lookup                 | Array of Songwriter 3 Original Pub. 2 fields in linked Compositions records.     |
+| Songwriter 3 Admin Pub. 1 (from Compositions 3)                            | `fldSaf0x3TudFzxCW` | Lookup                 | Array of Songwriter 3 Admin Pub. 1 fields in linked Compositions records.        |
+| Songwriter 3 Original Pub. 1 Share (from Compositions 3)                   | `fldJcEVpOUZMlzuoe` | Lookup                 | Array of Songwriter 3 Original Pub. 1 Share fields in linked Compositions records. |
+| Songwriter 3 Original Pub. 1 (from Compositions 3)                         | `fldSTX9gBFsrNSJs1` | Lookup                 | Array of Songwriter 3 Original Pub. 1 fields in linked Compositions records.     |
+| Songwriter 3 Ownership (from Compositions 3)                               | `fldh7PogF6xtGfHZT` | Lookup                 | Array of Songwriter 3 Ownership fields in linked Compositions records.           |
+| Songwriter 3 (from Compositions 3)                                         | `fldzmlgoAfJPt7yDb` | Lookup                 | Array of Songwriter 3 fields in linked Compositions records.                     |
+| Songwriter 2 Original Pub 3 Share (from Compositions 3)                    | `fldS4JaF0jG0ebGmz` | Lookup                 | Array of Songwriter 2 Original Pub 3 Share fields in linked Compositions records. |
+| Songwriter 2 Original Pub. 3 (from Compositions 3)                         | `fldHTEEnSFfeL5oED` | Lookup                 | Array of Songwriter 2 Original Pub. 3 fields in linked Compositions records.     |
+| Songwriter 2 Admin Pub. 2 (from Compositions 3)                            | `fldk2eZkFwKyoLLMv` | Lookup                 | Array of Songwriter 2 Admin Pub. 2 fields in linked Compositions records.        |
+| Songwriter 2 Original Pub. 2 Share (from Compositions 3)                   | `fldStQd0MevxiZDzE` | Lookup                 | Array of Songwriter 2 Original Pub. 2 Share fields in linked Compositions records. |
+| Songwriter 2 Original Pub. 2 (from Compositions 3)                         | `fldaGgIYxbJnB7WEm` | Lookup                 | Array of Songwriter 2 Original Pub. 2 fields in linked Compositions records.     |
+| Songwriter 2 Admin Pub 1 (from Compositions 3)                             | `fldllbYPy1lTa5bOu` | Lookup                 | Array of Songwriter 2 Admin Pub 1 fields in linked Compositions records.         |
+| Songwriter 2 Original Pub. 1 Share (from Compositions 3)                   | `fldtlwURA4fsjJszs` | Lookup                 | Array of Songwriter 2 Original Pub. 1 Share fields in linked Compositions records. |
+| Songwriter 2 Original Pub. 1 (from Compositions 3)                         | `fld9bwtPB0gOFiNgY` | Lookup                 | Array of Songwriter 2 Original Pub. 1 fields in linked Compositions records.     |
+| Songwriter 2 Share (from Compositions 3)                                   | `fldC30jlJIFd9x7DS` | Lookup                 | Array of Songwriter 2 Share fields in linked Compositions records.               |
+| Songwriter 2 (from Compositions 3)                                         | `fldpGjA2Toxf6QAjo` | Lookup                 | Array of Songwriter 2 fields in linked Compositions records.                     |
+| Songwriter 1 Admin Pub 3 (from Compositions 3)                             | `fldTOPVECeTZqd6R4` | Lookup                 | Array of Songwriter 1 Admin Pub 3 fields in linked Compositions records.         |
+| Songwriter 1 Original Pub 3 Share (from Compositions 3)                    | `fldCswARNEvCieTOT` | Lookup                 | Array of Songwriter 1 Original Pub 3 Share fields in linked Compositions records. |
+| Songwriter 1 Original Pub 3 (from Compositions 3)                          | `fldah64qGdVJAcEAS` | Lookup                 | Array of Songwriter 1 Original Pub 3 fields in linked Compositions records.      |
+| Songwriter 1 Admin Pub 2 (from Compositions 3)                             | `fldGAJVFC2AOaVLxQ` | Lookup                 | Array of Songwriter 1 Admin Pub 2 fields in linked Compositions records.         |
+| Songwriter 1 Original Pub 2 Share (from Compositions 3)                    | `fldHGsr00T0PvIKSc` | Lookup                 | Array of Songwriter 1 Original Pub 2 Share fields in linked Compositions records. |
+| Publishers                                                                 | `fldOnlBxEWrms5wK9` | Text                   | A single line of text.                                                           |
+| Address (from Songwriter 1 Admin Pub 1) (from Compositions)                | `fldV0Ec1vvjsIGEFT` | Lookup                 | Array of Address (from Songwriter 1 Admin Pub 1) fields in linked Compositions records. |
+| Email (from Songwriter 1 Admin Pub 1) (from Compositions)                  | `fldQsampavUVZBSSy` | Lookup                 | Array of Email (from Songwriter 1 Admin Pub 1) fields in linked Compositions records. |
+| Songwriter 2                                                               | `fldFdjAv05PGmHB1B` | Lookup                 | Array of Songwriter 2 fields in linked Compositions records.                     |
+| Songwriter 2 Share                                                         | `fldIGUs3EAoS7lM4r` | Lookup                 | Array of Songwriter 2 Share fields in linked Compositions records.               |
+| Songwriter 2 Original Pub 1                                                | `fldZel72It1bkOTdP` | Lookup                 | Array of Songwriter 2 Original Pub. 1 fields in linked Compositions records.     |
+| Songwriter 2 Admin Pub 1 (from Compositions)                               | `fldmDmDx7XzylBVD7` | Lookup                 | Array of Songwriter 2 Admin Pub 1 fields in linked Compositions records.         |
+| Address (from Songwriter 2 Admin Pub 1) (from Compositions)                | `fldMqzHnajmvfxnGV` | Lookup                 | Array of Address (from Songwriter 2 Admin Pub 1) fields in linked Compositions records. |
+| Email (from Songwriter 2 Admin Pub 1) (from Compositions)                  | `fldvfo7EwvVNvXcVG` | Lookup                 | Array of Email (from Songwriter 2 Admin Pub 1) fields in linked Compositions records. |
+| Songwriter 3                                                               | `fldUlgwjHScBOE7bC` | Lookup                 | Array of Songwriter 3 fields in linked Compositions records.                     |
+| Songwriter 3 Share                                                         | `fldPcYUR3fVXRLEPC` | Lookup                 | Array of Songwriter 3 Ownership fields in linked Compositions records.           |
+| Songwriter 3 Original Pub 1                                                | `fld66JPRd6OYmWqjV` | Lookup                 | Array of Songwriter 3 Original Pub. 1 fields in linked Compositions records.     |
+| Songwriter 3 Admin Pub 1 (from Compositions)                               | `fldvrnaL7dHgvwk8v` | Lookup                 | Array of Songwriter 3 Admin Pub. 1 fields in linked Compositions records.        |
+| Address (from Songwriter 3 Admin Pub 1) (from Compositions) copy           | `fldIQqqUlLmfCxYgL` | Lookup                 | Array of Address (from Songwriter 3 Admin Pub. 1) fields in linked Compositions records. |
+| Email (from Songwriter 3 Admin Pub 1) (from Compositions)                  | `fldUM1TeDK1gubphP` | Lookup                 | Array of Email (from Songwriter 3 Admin Pub. 1) fields in linked Compositions records. |
+| Songwriter 4                                                               | `fldiAvxWW6Z18r47j` | Lookup                 | Array of Songwriter 4 fields in linked Compositions records.                     |
+| Songwriter 4 Share                                                         | `fldonI9pItThOiHTc` | Lookup                 | Array of Songwriter 4 Ownership fields in linked Compositions records.           |
+| Songwriter 4 Original Pub 1                                                | `fldGwKMtL2yXdgCDB` | Lookup                 | Array of Songwriter 4 Original Pub. 1 fields in linked Compositions records.     |
+| Songwriter 4 Admin Pub 1 (from Compositions)                               | `fld4vxi4NUCT5mixJ` | Lookup                 | Array of Songwriter 4 Admin Pub. 1 fields in linked Compositions records.        |
+| Address (from Songwriter 4 Admin Pub 1) (from Compositions)                | `fldLHe4aP8n6IcY8q` | Lookup                 | Array of Address (from Songwriter 4 Admin Pub. 1) fields in linked Compositions records. |
+| Email (from Songwriter 4 Admin Pub 1) (from Compositions)                  | `fldcQyiyLJyTcBjNd` | Lookup                 | Array of Email (from Songwriter 4 Admin Pub. 1) fields in linked Compositions records. |
+| Songwriter 1 Original Pub 1 Share                                          | `fld8aEbU3LEw8tM0t` | Lookup                 | Array of Songwriter 1 Original Pub 1 Share fields in linked Compositions records. |
+| Songwriter 2 Original Pub 1 Share                                          | `fldUFESp3KoJ5JDSt` | Lookup                 | Array of Songwriter 2 Original Pub. 1 Share fields in linked Compositions records. |
+| Songwriter 2 Original Pub 2                                                | `fldkbGBVJDtaa4PJ3` | Lookup                 | Array of Songwriter 2 Original Pub. 2 fields in linked Compositions records.     |
+| Songwriter 2 Original Pub 2 Share                                          | `fldgLQUp0FNQk3dFO` | Lookup                 | Array of Songwriter 2 Original Pub. 2 Share fields in linked Compositions records. |
+| Songwriter 2 Admin Pub 2 (from Compositions)                               | `fldyOkV7xmWJOEejH` | Lookup                 | Array of Songwriter 2 Admin Pub. 2 fields in linked Compositions records.        |
+| Address (from Songwriter 2 Admin Pub 2) (from Compositions) copy           | `fldZIV83LicrrL6pg` | Lookup                 | Array of Address (from Songwriter 2 Admin Pub. 2) fields in linked Compositions records. |
+| Email (from Songwriter 2 Admin Pub 2) (from Compositions)                  | `fldB8hG1fz4ES5azS` | Lookup                 | Array of Email (from Songwriter 2 Admin Pub. 2) fields in linked Compositions records. |
+| Songwriter 1 Original Pub 2                                                | `fldizhy41Trowgkaw` | Lookup                 | Array of Songwriter 1 Original Pub 2 fields in linked Compositions records.      |
+| Songwriter 1 Admin Pub 2 (from Compositions)                               | `fldJ2MkBq0EFsCLPe` | Lookup                 | Array of Songwriter 1 Admin Pub 2 fields in linked Compositions records.         |
+| Address (from Songwriter 1 Admin Pub 2) (from Compositions)                | `fldm1ERS0JH6TM8QN` | Lookup                 | Array of Address (from Songwriter 1 Admin Pub 2) fields in linked Compositions records. |
+| Email (from Songwriter 1 Admin Pub 2) (from Compositions)                  | `fldEHUrL0HltClruH` | Lookup                 | Array of Email (from Songwriter 1 Admin Pub 2) fields in linked Compositions records. |
+| Songwriter 3 Original Pub 1 Share                                          | `fldZ8nwVHcdhSgB1a` | Lookup                 | Array of Songwriter 3 Original Pub. 1 Share fields in linked Compositions records. |
+| Songwriter 4 Original Pub 1 Share                                          | `fld697YMVrOs5w2ye` | Lookup                 | Array of Songwriter 4 Original Pub. 1 Share fields in linked Compositions records. |
+| Songwriter 3 Original Pub 2                                                | `fldkyxlUt0dwBvxA1` | Lookup                 | Array of Songwriter 3 Original Pub. 2 fields in linked Compositions records.     |
+| Songwriter 3 Original Pub 2 Share                                          | `fld4BIX7cPa3N9Mqo` | Lookup                 | Array of Songwriter 3 Original Pub. 2 Share fields in linked Compositions records. |
+| Songwriter 3 Admin Pub 2 (from Compositions)                               | `fldY45SlOWqxk21Bk` | Lookup                 | Array of Songwriter 3 Admin Pub. 2 fields in linked Compositions records.        |
+| Address (from Songwriter 3 Admin Pub 2) (from Compositions)                | `fldpVsFyzLorG0BWJ` | Lookup                 | Array of Address (from Songwriter 3 Admin Pub. 2) fields in linked Compositions records. |
+| Email (from Songwriter 3 Admin Pub 2) (from Compositions)                  | `fldrGUYK5kJPn43IO` | Lookup                 | Array of Email (from Songwriter 3 Admin Pub. 2) fields in linked Compositions records. |
+| Songwriter 4 Original Pub 2                                                | `fldHK79x9ayZ4zd63` | Lookup                 | Array of Songwriter 4 Original Pub 2 fields in linked Compositions records.      |
+| Songwriter 4 Original Pub 2 Share                                          | `fldgxGuyGT3Pzzg4R` | Lookup                 | Array of Songwriter 4 Original Pub 2 Share fields in linked Compositions records. |
+| Songwriter 4 Admin Pub 2 (from Compositions)                               | `fldwmKIgBEzf4bxry` | Lookup                 | Array of Songwriter 4 Admin Pub. 2 fields in linked Compositions records.        |
+| Address (from Songwriter 4 Admin Pub 4) (from Compositions)                | `fldER2erykqBXogm3` | Lookup                 | Array of Address (from Songwriter 4 Admin Pub. 2) fields in linked Compositions records. |
+| Email (from Songwriter 4 Admin Pub 2) (from Compositions)                  | `fld5Qv0383IhIF6NJ` | Lookup                 | Array of Email (from Songwriter 4 Admin Pub. 2) fields in linked Compositions records. |
+| disco updated                                                              | `fldJO5qT2kUG9xLvx` | Checkbox               | This field is "true" when checked and otherwise empty.                           |
+| Controlled by HFA (from Songwriter 1 Original Pub 1) (from Compositions)   | `fldXmFTDrMqC5RRO7` | Lookup                 | Array of Controlled by HFA (from Songwriter 1 Original Pub 1) fields in linked Compositions records. |
+| Controlled by HFA (from Songwriter 1 Admin Pub 1) (from Compositions)      | `flduFTwgf2giksdOE` | Lookup                 | Array of Controlled by HFA (from Songwriter 1 Admin Pub 1) fields in linked Compositions records. |
+| Controlled by HFA (from Songwriter 1 Original Pub 1) (from Compositions) 2 | `fldAOIZNEV9zBAuPq` | Lookup                 | Array of Controlled by HFA (from Songwriter 1 Original Pub 2) fields in linked Compositions records. |
+| Controlled by HFA (from Songwriter 1 Admin Pub 2) (from Compositions)      | `fldRUyr40Ne3WKXZu` | Lookup                 | Array of Controlled by HFA (from Songwriter 1 Admin Pub 2) fields in linked Compositions records. |
+| Controlled by HFA (from Songwriter 2 Original Pub. 1) (from Compositions)  | `fld4z0lHeV0ux5G76` | Lookup                 | Array of Controlled by HFA (from Songwriter 2 Original Pub. 1) fields in linked Compositions records. |
+| Controlled by HFA (from Songwriter 2 Admin Pub 1) (from Compositions)      | `fldClAgha2xV7qMXv` | Lookup                 | Array of Controlled by HFA (from Songwriter 2 Admin Pub 1) fields in linked Compositions records. |
+| Controlled by HFA (from Songwriter 2 Original Pub. 2) (from Compositions)  | `fld3zzUZbK23Lzj2D` | Lookup                 | Array of Controlled by HFA (from Songwriter 2 Original Pub. 2) fields in linked Compositions records. |
+| Controlled by HFA (from Songwriter 2 Admin Pub. 2) (from Compositions)     | `fldfO7BOjtyQfvVDu` | Lookup                 | Array of Controlled by HFA (from Songwriter 2 Admin Pub. 2) fields in linked Compositions records. |
+| Controlled by HFA (from Songwriter 3 Original Pub. 1) (from Compositions)  | `fldkEivwSubMqHPJl` | Lookup                 | Array of Controlled by HFA (from Songwriter 3 Original Pub. 1) fields in linked Compositions records. |
+| Controlled by HFA (from Songwriter 3 Admin Pub. 1) (from Compositions)     | `fldNx8VwSviNfdeSv` | Lookup                 | Array of Controlled by HFA (from Songwriter 3 Admin Pub. 1) fields in linked Compositions records. |
+| Controlled by HFA (from Songwriter 3 Original Pub. 2) (from Compositions)  | `fld3FvPAS0gxb7e4q` | Lookup                 | Array of Controlled by HFA (from Songwriter 3 Original Pub. 2) fields in linked Compositions records. |
+| Controlled by HFA (from Songwriter 3 Admin Pub. 2) (from Compositions)     | `fldmcrHwtqP09zA4I` | Lookup                 | Array of Controlled by HFA (from Songwriter 3 Admin Pub. 2) fields in linked Compositions records. |
+| Controlled by HFA (from Songwriter 4 Original Pub. 1) (from Compositions)  | `fldH8egiamDc2xSXx` | Lookup                 | Array of Controlled by HFA (from Songwriter 4 Original Pub. 1) fields in linked Compositions records. |
+| Controlled by HFA (from Songwriter 4 Admin Pub. 1) (from Compositions)     | `fldBHQuI0Hjzdld4M` | Lookup                 | Array of Controlled by HFA (from Songwriter 4 Admin Pub. 1) fields in linked Compositions records. |
+| Controlled by HFA (from Songwriter 4 Original Pub 2) (from Compositions)   | `fldc1tagiGVCkURMt` | Lookup                 | Array of Controlled by HFA (from Songwriter 4 Original Pub 2) fields in linked Compositions records. |
+| Controlled by HFA (from Songwriter 4 Admin Pub. 2) (from Compositions)     | `fldVJshLiDRpdujNV` | Lookup                 | Array of Controlled by HFA (from Songwriter 4 Admin Pub. 2) fields in linked Compositions records. |
+| Streaming Platforms                                                        | `fldIeQcESbP02bbkv` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| APM Dist Mgmt                                                              | `flddt6bS2GN56LUQY` | Link to another record | Array of linked records IDs from the APM Dist Mgmt table.                        |
+| Chevy Showroom Dist Mgmt                                                   | `flddAZaL7CL5QwgH1` | Link to another record | Array of linked records IDs from the Chevy Showroom Dist Mgmt table.             |
+| Key                                                                        | `fld0Ao29ExvUiQU6U` | Text                   | A single line of text.                                                           |
+| Legal Docs                                                                 | `fldVZMnGqosAZKLjf` | Link to another record | Array of linked records IDs from the Legal Docs table.                           |
+| Update Disco.ac                                                            | `fldROBYkBoJhMiBoL` | Button                 | Object providing details about the button configuration. label string button label url string for "Open URL" actions, the computed url value |
+| Disco Track ID                                                             | `fldgOnrMjSpiLjaaU` | Text                   | A single line of text.                                                           |
+| REGISTRATION PROJECT (PRO +MLC)                                            | `fldEUVTZBGYl5tb0v` | Link to another record | Array of linked records IDs from the REGISTRATION PROJECT (PRO +MLC) table.      |
+| Union Representation                                                       | `fldYYoXVIcZdVHptC` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/recordings`
+
+To list records in Recordings , issue a GET request to the Recordings endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Returned records do not include any fields with "empty" values, e.g. "" , [] , or false .
+
+```bash
+curl "https://api.airtable.com/v0/appEurfA8kXQE3slK/Recordings?maxRecords=3&view=Update%20missing%20songwriters%20%28Orchard%2FSpotify%29" \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+### Query Parameters
+
+| Parameter               | Type             | Required   | Description                                                                      |
+| ----------------------- | ---------------- | ---------- | -------------------------------------------------------------------------------- |
+| `fields`                | array of strings | optional   | Only data for fields whose names are in this list will be included in the result. If you don't need every field, you can use this parameter to reduce the amount of data transferred. For example, to only return data from Title of Recording and ISRC , send these two query parameters: fields%5B%5D=Titl |
+| `filterByFormula`       | string           | optional   | A formula used to filter records. The formula will be evaluated for each record, and if the result is not 0 , false , "" , NaN , [] , or #Error! the record will be included in the response. We recommend testing your formula in the Formula field UI before using it in your API request. If combined wit |
+| `maxRecords`            | number           | optional   | The maximum total number of records that will be returned in your requests. If this value is larger than pageSize (which is 100 by default), you may have to load multiple pages to reach this total. See the Pagination section below for more. |
+| `pageSize`              | number           | optional   | The number of records returned in each request. Must be less than or equal to 100. Default is 100. See the Pagination section below for more. |
+| `sort`                  | array of objects | optional   | A list of sort objects that specifies how the records will be ordered. Each sort object must have a field key specifying the name of the field to sort on, and an optional direction key that is either "asc" or "desc" . The default direction is "asc" . The sort parameter overrides the sorting of the v |
+| `view`                  | string           | optional   | The name or ID of a view in the Recordings table. If set, only the records in that view will be returned. The records will be sorted according to the order of the view unless the sort parameter is included, which overrides that order. Fields hidden in this view will be returned in the results. To on |
+| `cellFormat`            | string           | optional   | The format that should be used for cell values. Supported values are: json : cells will be formatted as JSON, depending on the field type. string : cells will be formatted as user-facing strings, regardless of the field type. The timeZone and userLocale parameters are required when using string as t |
+| `timeZone`              | string           | optional   | The time zone that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `userLocale`            | string           | optional   | The user locale that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `returnFieldsByFieldId` | boolean          | optional   | An optional boolean value that lets you return field objects where the key is the field id. This defaults to false , which returns field objects where the key is the field name. |
+| `recordMetadata`        | array of strings | optional   | An optional field that, if includes commentCount , adds a commentCount read only property on each record returned. |
+
+---
+
+## Retrieve a Record
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/recordings`
+
+To retrieve an existing record in Recordings table, issue a GET request to the record endpoint.
+
+Any "empty" fields (e.g. "" , [] , or false ) in the record will not be returned.
+
+```bash
+curl https://api.airtable.com/v0/appEurfA8kXQE3slK/Recordings/recQcYvBnCfLZQfOe \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+---
+
+## Create Records
+
+**Endpoint:** `POST /v0/appEurfA8kXQE3slK/recordings`
+
+To create new records, issue a POST request to the Recordings endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have one key whose value is an inner object containing your record's cell values, keyed by either field name or field id.
+
+```bash
+curl -X POST https://api.airtable.com/v0/appEurfA8kXQE3slK/Recordings \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "fields": {
+        "Title of Recording": "It'\''s Too Soon To Know - Live On The Pat Boone Chevy Showroom, January 23, 1958",
+        "ISRC": "QT27V2500069",
+        "Missing songwriter on Spotify": "Not yet assessed",
+        "All Releases": [
+          "recgtlNBGGu08mUot"
+        ],
+        "Compositions": [
+          "recbOVTanUjBSvUwI"
+        ],
+        "Master Owner 1": [
+          "recmbD0S2y6gdZY0M"
+        ],
+        "Master 1 Ownership": 1,
+        "REGISTRATION PROJECT (SOUNDEXCHANGE) 3": [
+          "reckGberWwlebdUXg"
+        ],
+        "PBGL Owned": true,
+        "Primary Artist": [
+          "recLWgt9qnlgDkkAo"
+        ],
+        "Original Release": [
+          "recgtlNBGGu08mUot"
+        ],
+        "Master": "https://app.box.com/s/lobp56o8kpwilth0rm99r7e3xtcr1kas",
+        "Date of original Release": "2025-10-31",
+        "Tempo Tag": "Downtempo",
+        "Mood Tag": [
+          "Dreamy",
+          "Romantic",
+          "Warm"
+        ],
+        "Genre Tag": [
+          "R&B",
+          "Rock N Roll"
+        ],
+        "Vocal Tag": [
+          "Male vocal",
+          "Background vocals"
+        ],
+        "Instruments Tag": [
+          "Electric Bass",
+          "Orchestral",
+          "Piano",
+          "Strings"
+        ],
+        "Lyrical Theme Tag": [
+          "Desire",
+          "Heartbreak",
+          "Love"
+        ],
+        "Duration": 164,
+        "DISCO": "https://s.disco.ac/njwcsfbkonse",
+        "Era": "1950s",
+        "Ready for Sync": "Yes",
+        "Recording year": "1958",
+        "Status": [
+          "In progress"
+        ],
+        "Priority": "N/A",
+        "disco updated": true,
+        "Chevy Showroom Dist Mgmt": [
+          "reczvmZSIkqvTmciC"
+        ],
+        "Disco Track ID": "123502181",
+        "Union Representation": [
+          "Not yet assessed"
+        ]
+      }
+    },
+    {
+      "fields": {
+        "Title of Recording": "Under God",
+        "Missing songwriter on Spotify": "Not distributed on Spotify",
+        "All Releases": [
+          "recIJwdEoRhNM5a7r"
+        ],
+        "Primary Artist": [
+          "recLWgt9qnlgDkkAo"
+        ],
+        "Original Release": [
+          "recIJwdEoRhNM5a7r"
+        ],
+        "Date of original Release": "2020-11-20",
+        "Tempo Tag": "Midtempo",
+        "Mood Tag": [
+          "Happy",
+          "Joyful",
+          "Celebratory"
+        ],
+        "Genre Tag": [
+          "Gospel",
+          "Pop",
+          "Rock N Roll"
+        ],
+        "Vocal Tag": [
+          "Male Lead",
+          "Female Backup"
+        ],
+        "Instruments Tag": [
+          "Drums",
+          "Electric Bass",
+          "Electric Guitar",
+          "Organ",
+          "Synth"
+        ],
+        "Lyrical Theme Tag": [
+          "Freedom",
+          "Religious",
+          "Storytelling"
+        ],
+        "Duration": 259,
+        "Era": "2020s",
+        "Ready for Sync": "No",
+        "Type Tag": [
+          "Rerecord"
+        ],
+        "Union Representation": [
+          "Not yet assessed"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Update / Upsert Records
+
+**Endpoint:** `PATCH /v0/appEurfA8kXQE3slK/recordings`
+
+To update Recordings records, issue a request to the Recordings endpoint. Table names and table IDs can be used interchangeably. Using table IDs means table name changes won't require modifying your API request code. A PATCH request will only update the fields included in the request. Fields not included in the request will be unchanged. A PUT request will perform a destructive update and clear all unincluded cell values.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have an id property representing the record ID and a fields property which contains all of your record's cell values by field name or field id for all of your record's cell values by field name.
+
+```bash
+curl -X PATCH https://api.airtable.com/v0/appEurfA8kXQE3slK/Recordings \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "id": "recQcYvBnCfLZQfOe",
+      "fields": {
+        "Title of Recording": "It'\''s Too Soon To Know - Live On The Pat Boone Chevy Showroom, January 23, 1958",
+        "ISRC": "QT27V2500069",
+        "Missing songwriter on Spotify": "Not yet assessed",
+        "All Releases": [
+          "recgtlNBGGu08mUot"
+        ],
+        "Compositions": [
+          "recbOVTanUjBSvUwI"
+        ],
+        "Master Owner 1": [
+          "recmbD0S2y6gdZY0M"
+        ],
+        "Master 1 Ownership": 1,
+        "REGISTRATION PROJECT (SOUNDEXCHANGE) 3": [
+          "reckGberWwlebdUXg"
+        ],
+        "PBGL Owned": true,
+        "Primary Artist": [
+          "recLWgt9qnlgDkkAo"
+        ],
+        "Original Release": [
+          "recgtlNBGGu08mUot"
+        ],
+        "Master": "https://app.box.com/s/lobp56o8kpwilth0rm99r7e3xtcr1kas",
+        "Date of original Release": "2025-10-31",
+        "Tempo Tag": "Downtempo",
+        "Mood Tag": [
+          "Dreamy",
+          "Romantic",
+          "Warm"
+        ],
+        "Genre Tag": [
+          "R&B",
+          "Rock N Roll"
+        ],
+        "Vocal Tag": [
+          "Male vocal",
+          "Background vocals"
+        ],
+        "Instruments Tag": [
+          "Electric Bass",
+          "Orchestral",
+          "Piano",
+          "Strings"
+        ],
+        "Lyrical Theme Tag": [
+          "Desire",
+          "Heartbreak",
+          "Love"
+        ],
+        "Duration": 164,
+        "DISCO": "https://s.disco.ac/njwcsfbkonse",
+        "Era": "1950s",
+        "Ready for Sync": "Yes",
+        "Recording year": "1958",
+        "Status": [
+          "In progress"
+        ],
+        "Priority": "N/A",
+        "disco updated": true,
+        "Chevy Showroom Dist Mgmt": [
+          "reczvmZSIkqvTmciC"
+        ],
+        "Disco Track ID": "123502181",
+        "Union Representation": [
+          "Not yet assessed"
+        ]
+      }
+    },
+    {
+      "id": "recPwb70VYoaxT1an",
+      "fields": {
+        "Title of Recording": "Under God",
+        "Missing songwriter on Spotify": "Not distributed on Spotify",
+        "All Releases": [
+          "recIJwdEoRhNM5a7r"
+        ],
+        "Primary Artist": [
+          "recLWgt9qnlgDkkAo"
+        ],
+        "Original Release": [
+          "recIJwdEoRhNM5a7r"
+        ],
+        "Date of original Release": "2020-11-20",
+        "Tempo Tag": "Midtempo",
+        "Mood Tag": [
+          "Happy",
+          "Joyful",
+          "Celebratory"
+        ],
+        "Genre Tag": [
+          "Gospel",
+          "Pop",
+          "Rock N Roll"
+        ],
+        "Vocal Tag": [
+          "Male Lead",
+          "Female Backup"
+        ],
+        "Instruments Tag": [
+          "Drums",
+          "Electric Bass",
+          "Electric Guitar",
+          "Organ",
+          "Synth"
+        ],
+        "Lyrical Theme Tag": [
+          "Freedom",
+          "Religious",
+          "Storytelling"
+        ],
+        "Duration": 259,
+        "Era": "2020s",
+        "Ready for Sync": "No",
+        "Type Tag": [
+          "Rerecord"
+        ],
+        "Union Representation": [
+          "Not yet assessed"
+        ]
+      }
+    },
+    {
+      "id": "recXeaNwgu672wE1H",
+      "fields": {
+        "Title of Recording": "The Old Rugged Cross ",
+        "ISRC": "US2R30912212",
+        "Missing songwriter on Spotify": "Not distributed on Spotify",
+        "All Releases": [
+          "rechJrbwuGtmmX3mq"
+        ],
+        "Compositions": [
+          "recqJ4gCumDthZJEl"
+        ],
+        "Master Owner 1": [
+          "rec52XnBYFVE0RgZ8"
+        ],
+        "Master 1 Ownership": 1,
+        "Spotify": "N/A",
+        "REGISTRATION PROJECT (SOUNDEXCHANGE) 3": [
+          "recEjTMy2xZLU2fP2"
+        ],
+        "PBGL Owned": true,
+        "Primary Artist": [
+          "recLWgt9qnlgDkkAo"
+        ],
+        "Original Release": [
+          "rechJrbwuGtmmX3mq"
+        ],
+        "Master": "https://app.box.com/s/ta6lo1vnwejfz4gb66ucm0ytgngl7q80",
+        "Date of original Release": "2015-05-12",
+        "Tempo Tag": "Downtempo",
+        "Mood Tag": [
+          "Wistful",
+          "Contemplative",
+          "Positive",
+          "Warm"
+        ],
+        "Genre Tag": [
+          "Christian",
+          "Gospel"
+        ],
+        "Vocal Tag": [
+          "Male Lead",
+          "Background vocals",
+          "Spoken"
+        ],
+        "Instruments Tag": [
+          "Bells",
+          "Acoustic Guitar",
+          "Piano",
+          "Upright Bass ",
+          "Organ",
+          "Drums"
+        ],
+        "Lyrical Theme Tag": [
+          "Religious",
+          "Appreciation",
+          "Love",
+          "Storytelling",
+          "Nature",
+          "Death",
+          "Life"
+        ],
+        "Duration": 250,
+        "DISCO": "https://s.disco.ac/bnudssskmxzb",
+        "Apple Music": "https://music.apple.com/in/album/the-old-rugged-cross/342564024?i=342564103",
+        "YouTube Music": "N/A",
+        "Soundcloud": "N/A",
+        "Amazon Music": "N/A",
+        "Era": "1990s",
+        "Ready for Sync": "No",
+        "Lyric Sheet": "https://app.box.com/s/3pbmo2nhi246w114nnuz3r3ej07nq92g",
+        "Type Tag": [
+          "Cover",
+          "Recognizable",
+          "Rerecord"
+        ],
+        "Streaming Platforms": [
+          "NOT YET ASSESSED"
+        ],
+        "APM Dist Mgmt": [
+          "recsU8h433Uaa5txE"
+        ],
+        "Disco Track ID": "90612188",
+        "Union Representation": [
+          "Non-Union"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Delete Records
+
+**Endpoint:** `DELETE /v0/appEurfA8kXQE3slK/recordings`
+
+To delete Recordings records, issue a DELETE request to the Recordings endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request should include a URL-encoded array of up to 10 record IDs to delete.
+
+```bash
+curl -X DELETE https://api.airtable.com/v0/appEurfA8kXQE3slK/Recordings \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -G \
+  --data-urlencode 'records[]=recQcYvBnCfLZQfOe' \
+  --data-urlencode 'records[]=recPwb70VYoaxT1an'
+```
+

--- a/DOCS/AIRTABLE_API/registration-project-pro-mlc.md
+++ b/DOCS/AIRTABLE_API/registration-project-pro-mlc.md
@@ -1,0 +1,214 @@
+# REGISTRATION PROJECT (PRO +MLC)
+
+**Table ID:** `tbl7FGL9AZlKaqOwm`  
+**Base ID:** `appEurfA8kXQE3slK`
+
+---
+
+## Fields
+
+| Field Name                                    | Field ID            | Type                   | Description                                                                      |
+| --------------------------------------------- | ------------------- | ---------------------- | -------------------------------------------------------------------------------- |
+| Name                                          | `fldBvNz4tqZnZvFsb` | Text                   | A single line of text.                                                           |
+| Compositions                                  | `fldHiMGgWMpTNCQmV` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Notes                                         | `fldTQSIXC6JxPwfad` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| Album                                         | `fldnqyyBlGLy1aynQ` | Text                   | A single line of text.                                                           |
+| Song Title In PRO (from Compositions)         | `fldzX2NrXWLrLP7VJ` | Lookup                 | Array of Song Title In PRO fields in linked Compositions records.                |
+| Recordings (from Compositions)                | `fldwiWBv6UPr8QhoN` | Lookup                 | Array of Recordings fields in linked Compositions records.                       |
+| All Songwriters (from Compositions)           | `fldssbpk1rZaIH8JQ` | Lookup                 | Array of All Songwriters fields in linked Compositions records.                  |
+| All Original Publishers (from Compositions)   | `fldmHr6i3FsHrYpj0` | Lookup                 | Array of All Original Publishers fields in linked Compositions records.          |
+| All Admin Publishers (from Compositions)      | `fldcvv5IX1gyWBL4W` | Lookup                 | Array of All Admin Publishers fields in linked Compositions records.             |
+| Involved PROs (from Compositions)             | `fldaItWbLND7ehdgP` | Lookup                 | Array of Involved PROs fields in linked Compositions records.                    |
+| Releases (from Compositions)                  | `fldFvEichGHuAMsqH` | Lookup                 | Array of Releases fields in linked Compositions records.                         |
+| ISWC (from Compositions)                      | `fldDdwjU6NevzbHUo` | Lookup                 | Array of ISWC fields in linked Compositions records.                             |
+| PROs                                          | `fld9cuXBmdB2JWasO` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Recordings (from Composition)                 | `fldzapq4yl5ZSkcg5` | Lookup                 | Array of Recordings fields in linked Compositions records.                       |
+| MLC Song Code (from Compositions)             | `fldqYlEiwg1FNJS3R` | Lookup                 | Array of MLC Song Code fields in linked Compositions records.                    |
+| MLC work links (from Compositions)            | `fldXU3Nz2BnzAWMqr` | Lookup                 | Array of MLC work links fields in linked Compositions records.                   |
+| Last Modified                                 | `fld1xXEiNXAoEXUbK` | Formula                | Computed value: LAST_MODIFIED_TIME() .                                           |
+| MLC Status                                    | `fld9ybfZN4DlAjpKh` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Matched Recording on MLC                      | `fldTTsqgKn6xtbFKy` | Link to another record | Array of linked records IDs from the Recordings table.                           |
+| Recordings that need to be matched on The MLC | `fld3f4yh84I7JowYu` | Lookup                 | Array of Recordings fields in linked Compositions records.                       |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/registration%20project%20(pro%20+mlc)`
+
+To list records in REGISTRATION PROJECT (PRO +MLC) , issue a GET request to the REGISTRATION PROJECT (PRO +MLC) endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Returned records do not include any fields with "empty" values, e.g. "" , [] , or false .
+
+```bash
+curl "https://api.airtable.com/v0/appEurfA8kXQE3slK/REGISTRATION%20PROJECT%20(PRO%20%2BMLC)?maxRecords=3&view=Grid%20view" \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+### Query Parameters
+
+| Parameter               | Type             | Required   | Description                                                                      |
+| ----------------------- | ---------------- | ---------- | -------------------------------------------------------------------------------- |
+| `fields`                | array of strings | optional   | Only data for fields whose names are in this list will be included in the result. If you don't need every field, you can use this parameter to reduce the amount of data transferred. For example, to only return data from Name and Compositions , send these two query parameters: fields%5B%5D=Name&field |
+| `filterByFormula`       | string           | optional   | A formula used to filter records. The formula will be evaluated for each record, and if the result is not 0 , false , "" , NaN , [] , or #Error! the record will be included in the response. We recommend testing your formula in the Formula field UI before using it in your API request. If combined wit |
+| `maxRecords`            | number           | optional   | The maximum total number of records that will be returned in your requests. If this value is larger than pageSize (which is 100 by default), you may have to load multiple pages to reach this total. See the Pagination section below for more. |
+| `pageSize`              | number           | optional   | The number of records returned in each request. Must be less than or equal to 100. Default is 100. See the Pagination section below for more. |
+| `sort`                  | array of objects | optional   | A list of sort objects that specifies how the records will be ordered. Each sort object must have a field key specifying the name of the field to sort on, and an optional direction key that is either "asc" or "desc" . The default direction is "asc" . The sort parameter overrides the sorting of the v |
+| `view`                  | string           | optional   | The name or ID of a view in the REGISTRATION PROJECT (PRO +MLC) table. If set, only the records in that view will be returned. The records will be sorted according to the order of the view unless the sort parameter is included, which overrides that order. Fields hidden in this view will be returned |
+| `cellFormat`            | string           | optional   | The format that should be used for cell values. Supported values are: json : cells will be formatted as JSON, depending on the field type. string : cells will be formatted as user-facing strings, regardless of the field type. The timeZone and userLocale parameters are required when using string as t |
+| `timeZone`              | string           | optional   | The time zone that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `userLocale`            | string           | optional   | The user locale that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `returnFieldsByFieldId` | boolean          | optional   | An optional boolean value that lets you return field objects where the key is the field id. This defaults to false , which returns field objects where the key is the field name. |
+| `recordMetadata`        | array of strings | optional   | An optional field that, if includes commentCount , adds a commentCount read only property on each record returned. |
+
+---
+
+## Retrieve a Record
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/registration%20project%20(pro%20+mlc)`
+
+To retrieve an existing record in REGISTRATION PROJECT (PRO +MLC) table, issue a GET request to the record endpoint.
+
+Any "empty" fields (e.g. "" , [] , or false ) in the record will not be returned.
+
+```bash
+curl https://api.airtable.com/v0/appEurfA8kXQE3slK/REGISTRATION%20PROJECT%20(PRO%20%2BMLC)/recIDEqF2cwZpLdL3 \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+---
+
+## Create Records
+
+**Endpoint:** `POST /v0/appEurfA8kXQE3slK/registration%20project%20(pro%20+mlc)`
+
+To create new records, issue a POST request to the REGISTRATION PROJECT (PRO +MLC) endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have one key whose value is an inner object containing your record's cell values, keyed by either field name or field id.
+
+```bash
+curl -X POST https://api.airtable.com/v0/appEurfA8kXQE3slK/REGISTRATION%20PROJECT%20(PRO%20%2BMLC) \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "fields": {
+        "Name": "ABIDE WITH ME",
+        "Compositions": [
+          "recdFggjDdHANgq0p"
+        ],
+        "PROs": [
+          "ASCAP - Doublecheck or Claim"
+        ],
+        "MLC Status": [
+          "No Registration Found"
+        ]
+      }
+    },
+    {
+      "fields": {
+        "Name": "ABIDE WITH ME",
+        "Compositions": [
+          "recHn8Zy71HNYu8Cf"
+        ],
+        "Notes": "Already registered by SPOONE. ",
+        "PROs": [
+          "ASCAP claimed"
+        ],
+        "MLC Status": [
+          "Doublecheck or claim on MLC"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Update / Upsert Records
+
+**Endpoint:** `PATCH /v0/appEurfA8kXQE3slK/registration%20project%20(pro%20+mlc)`
+
+To update REGISTRATION PROJECT (PRO +MLC) records, issue a request to the REGISTRATION PROJECT (PRO +MLC) endpoint. Table names and table IDs can be used interchangeably. Using table IDs means table name changes won't require modifying your API request code. A PATCH request will only update the fields included in the request. Fields not included in the request will be unchanged. A PUT request will perform a destructive update and clear all unincluded cell values.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have an id property representing the record ID and a fields property which contains all of your record's cell values by field name or field id for all of your record's cell values by field name.
+
+```bash
+curl -X PATCH https://api.airtable.com/v0/appEurfA8kXQE3slK/REGISTRATION%20PROJECT%20(PRO%20%2BMLC) \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "id": "recIDEqF2cwZpLdL3",
+      "fields": {
+        "Name": "ABIDE WITH ME",
+        "Compositions": [
+          "recdFggjDdHANgq0p"
+        ],
+        "PROs": [
+          "ASCAP - Doublecheck or Claim"
+        ],
+        "MLC Status": [
+          "No Registration Found"
+        ]
+      }
+    },
+    {
+      "id": "recHTjxwxRjF9gZuQ",
+      "fields": {
+        "Name": "ABIDE WITH ME",
+        "Compositions": [
+          "recHn8Zy71HNYu8Cf"
+        ],
+        "Notes": "Already registered by SPOONE. ",
+        "PROs": [
+          "ASCAP claimed"
+        ],
+        "MLC Status": [
+          "Doublecheck or claim on MLC"
+        ]
+      }
+    },
+    {
+      "id": "reclItmqccgZSlU8t",
+      "fields": {
+        "Name": "ADESTE FIDELES ",
+        "Compositions": [
+          "recPVDBwFj577mY3c"
+        ],
+        "Notes": "12/11/25 This composition has been reverted from SWEET ON TOP PUBLISHING back to SPOONE MUSIC CORPORATION.",
+        "Album": "Family Christmas",
+        "PROs": [
+          "ASCAP claimed"
+        ],
+        "MLC Status": [
+          "Claimed by SONGS OF PEER",
+          "Claimed by SWEET ON TOP PUB"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Delete Records
+
+**Endpoint:** `DELETE /v0/appEurfA8kXQE3slK/registration%20project%20(pro%20+mlc)`
+
+To delete REGISTRATION PROJECT (PRO +MLC) records, issue a DELETE request to the REGISTRATION PROJECT (PRO +MLC) endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request should include a URL-encoded array of up to 10 record IDs to delete.
+
+```bash
+curl -X DELETE https://api.airtable.com/v0/appEurfA8kXQE3slK/REGISTRATION%20PROJECT%20(PRO%20%2BMLC) \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -G \
+  --data-urlencode 'records[]=recIDEqF2cwZpLdL3' \
+  --data-urlencode 'records[]=recHTjxwxRjF9gZuQ'
+```
+

--- a/DOCS/AIRTABLE_API/registration-project-soundexchange.md
+++ b/DOCS/AIRTABLE_API/registration-project-soundexchange.md
@@ -1,0 +1,207 @@
+# REGISTRATION PROJECT (SOUNDEXCHANGE)
+
+**Table ID:** `tbliX5cAVK47tYsL8`  
+**Base ID:** `appEurfA8kXQE3slK`
+
+---
+
+## Fields
+
+| Field Name                                                       | Field ID            | Type                   | Description                                                                      |
+| ---------------------------------------------------------------- | ------------------- | ---------------------- | -------------------------------------------------------------------------------- |
+| Name                                                             | `fldMNc0vObIKi3jHX` | Text                   | A single line of text.                                                           |
+| Notes                                                            | `fldG2kDhfvrFPe3oY` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| Album                                                            | `fldyIXZ2GruVkIcCC` | Text                   | A single line of text.                                                           |
+| Label Owned                                                      | `fld48h9oXRsU84TpZ` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| SX (Rights Owner)                                                | `fldwk3ye1YgdBmRgf` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| SX (Artist)                                                      | `fldwCzooBZxy2mdbV` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Recordings                                                       | `fld2j5Wejenu7sbM4` | Link to another record | Array of linked records IDs from the Recordings table.                           |
+| Title of Recording (from Recordings)                             | `fldqOGw788bhOC3Uu` | Lookup                 | Array of Title of Recording fields in linked Recordings records.                 |
+| All Releases (from Recordings)                                   | `fldIMUZgXS7x4Dbu2` | Lookup                 | Array of All Releases fields in linked Recordings records.                       |
+| Primary Artist (from Recordings)                                 | `fldd0wIZi79xyswWT` | Lookup                 | Array of Primary Artist fields in linked Recordings records.                     |
+| Featured Artist (from Recordings)                                | `fldwG49aMHD3WCgWT` | Lookup                 | Array of Featured Artist fields in linked Recordings records.                    |
+| ISRC (from Recordings)                                           | `fldpIo5kHVxRRBCfE` | Lookup                 | Array of ISRC fields in linked Recordings records.                               |
+| Spotify (from Recordings)                                        | `fld4FeUjzRgiew2FN` | Lookup                 | Array of Spotify fields in linked Recordings records.                            |
+| Master Owner 1 (from Recordings)                                 | `fld3dJ0p1tQNdnUBK` | Lookup                 | Array of Master Owner 1 fields in linked Recordings records.                     |
+| % Master 1 Ownership                                             | `fldoNHY5GTT5uwTYb` | Lookup                 | Array of Master 1 Ownership fields in linked Recordings records.                 |
+| Notes (from Recordings)                                          | `fldpi8FS02T746l2F` | Lookup                 | Array of Notes fields in linked Recordings records.                              |
+| Duration (from Recordings)                                       | `fldCRFi0yxT4mEh8r` | Lookup                 | Array of Duration fields in linked Recordings records.                           |
+| Genre Tag (from Recordings)                                      | `fldDeMyNbY0PckL4j` | Lookup                 | Array of Genre Tag fields in linked Recordings records.                          |
+| Recording year (from Recordings)                                 | `fldePy1jUKPCqMYHi` | Lookup                 | Array of Recording year fields in linked Recordings records.                     |
+| Date of original Release (from Recordings)                       | `fldY757FKyjiTQPTU` | Lookup                 | Array of Date of original Release fields in linked Recordings records.           |
+| ISWC (from Compositions) (from Recordings)                       | `fld30jpDmhTlSljwp` | Lookup                 | Array of ISWC (from Compositions) fields in linked Recordings records.           |
+| UPC (from Releases) (from Recordings)                            | `fldidmpkvsGAhimGf` | Lookup                 | Array of UPC (from Releases) fields in linked Recordings records.                |
+| Original release label (from Original release) (from Recordings) | `fld4yI3HU8QQVTifM` | Lookup                 | Array of Original release label (from Original release) fields in linked Recordings records. |
+| Current release label (from Original Release) (from Recordings)  | `fldnSB2qwxQ0lITlI` | Lookup                 | Array of Current release label (from Original Release) fields in linked Recordings records. |
+| Last Modified                                                    | `fldOs1Csu8wmfmt2c` | Formula                | Computed value: LAST_MODIFIED_TIME() .                                           |
+| PBGL Owned                                                       | `fldWxrR2rjZpKZlTe` | Lookup                 | Array of PBGL Owned fields in linked Recordings records.                         |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/registration%20project%20(soundexchange)`
+
+To list records in REGISTRATION PROJECT (SOUNDEXCHANGE) , issue a GET request to the REGISTRATION PROJECT (SOUNDEXCHANGE) endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Returned records do not include any fields with "empty" values, e.g. "" , [] , or false .
+
+```bash
+curl "https://api.airtable.com/v0/appEurfA8kXQE3slK/REGISTRATION%20PROJECT%20(SOUNDEXCHANGE)?maxRecords=3&view=Grid%20view" \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+### Query Parameters
+
+| Parameter               | Type             | Required   | Description                                                                      |
+| ----------------------- | ---------------- | ---------- | -------------------------------------------------------------------------------- |
+| `fields`                | array of strings | optional   | Only data for fields whose names are in this list will be included in the result. If you don't need every field, you can use this parameter to reduce the amount of data transferred. For example, to only return data from Name and Notes , send these two query parameters: fields%5B%5D=Name&fields%5B%5D |
+| `filterByFormula`       | string           | optional   | A formula used to filter records. The formula will be evaluated for each record, and if the result is not 0 , false , "" , NaN , [] , or #Error! the record will be included in the response. We recommend testing your formula in the Formula field UI before using it in your API request. If combined wit |
+| `maxRecords`            | number           | optional   | The maximum total number of records that will be returned in your requests. If this value is larger than pageSize (which is 100 by default), you may have to load multiple pages to reach this total. See the Pagination section below for more. |
+| `pageSize`              | number           | optional   | The number of records returned in each request. Must be less than or equal to 100. Default is 100. See the Pagination section below for more. |
+| `sort`                  | array of objects | optional   | A list of sort objects that specifies how the records will be ordered. Each sort object must have a field key specifying the name of the field to sort on, and an optional direction key that is either "asc" or "desc" . The default direction is "asc" . The sort parameter overrides the sorting of the v |
+| `view`                  | string           | optional   | The name or ID of a view in the REGISTRATION PROJECT (SOUNDEXCHANGE) table. If set, only the records in that view will be returned. The records will be sorted according to the order of the view unless the sort parameter is included, which overrides that order. Fields hidden in this view will be retu |
+| `cellFormat`            | string           | optional   | The format that should be used for cell values. Supported values are: json : cells will be formatted as JSON, depending on the field type. string : cells will be formatted as user-facing strings, regardless of the field type. The timeZone and userLocale parameters are required when using string as t |
+| `timeZone`              | string           | optional   | The time zone that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `userLocale`            | string           | optional   | The user locale that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `returnFieldsByFieldId` | boolean          | optional   | An optional boolean value that lets you return field objects where the key is the field id. This defaults to false , which returns field objects where the key is the field name. |
+| `recordMetadata`        | array of strings | optional   | An optional field that, if includes commentCount , adds a commentCount read only property on each record returned. |
+
+---
+
+## Retrieve a Record
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/registration%20project%20(soundexchange)`
+
+To retrieve an existing record in REGISTRATION PROJECT (SOUNDEXCHANGE) table, issue a GET request to the record endpoint.
+
+Any "empty" fields (e.g. "" , [] , or false ) in the record will not be returned.
+
+```bash
+curl https://api.airtable.com/v0/appEurfA8kXQE3slK/REGISTRATION%20PROJECT%20(SOUNDEXCHANGE)/recj1SM8RsYu6EXq6 \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+---
+
+## Create Records
+
+**Endpoint:** `POST /v0/appEurfA8kXQE3slK/registration%20project%20(soundexchange)`
+
+To create new records, issue a POST request to the REGISTRATION PROJECT (SOUNDEXCHANGE) endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have one key whose value is an inner object containing your record's cell values, keyed by either field name or field id.
+
+```bash
+curl -X POST https://api.airtable.com/v0/appEurfA8kXQE3slK/REGISTRATION%20PROJECT%20(SOUNDEXCHANGE) \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "fields": {
+        "Name": "He Leadeth Me",
+        "Album": "Golden Treasury of Hymns ",
+        "SX (Rights Owner)": [
+          "N/A"
+        ],
+        "SX (Artist)": [
+          "Claimed"
+        ]
+      }
+    },
+    {
+      "fields": {
+        "Name": "Merry Christmas ",
+        "Notes": "https://open.spotify.com/album/3RfMfyPLea5WD7lk0SpSXd?si=TexcLUEgTnm396FldEVJdg",
+        "Album": "Merry Christmas",
+        "SX (Rights Owner)": [
+          "N/A"
+        ],
+        "SX (Artist)": [
+          "Needs to be Submitted by RO"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Update / Upsert Records
+
+**Endpoint:** `PATCH /v0/appEurfA8kXQE3slK/registration%20project%20(soundexchange)`
+
+To update REGISTRATION PROJECT (SOUNDEXCHANGE) records, issue a request to the REGISTRATION PROJECT (SOUNDEXCHANGE) endpoint. Table names and table IDs can be used interchangeably. Using table IDs means table name changes won't require modifying your API request code. A PATCH request will only update the fields included in the request. Fields not included in the request will be unchanged. A PUT request will perform a destructive update and clear all unincluded cell values.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have an id property representing the record ID and a fields property which contains all of your record's cell values by field name or field id for all of your record's cell values by field name.
+
+```bash
+curl -X PATCH https://api.airtable.com/v0/appEurfA8kXQE3slK/REGISTRATION%20PROJECT%20(SOUNDEXCHANGE) \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "id": "recj1SM8RsYu6EXq6",
+      "fields": {
+        "Name": "He Leadeth Me",
+        "Album": "Golden Treasury of Hymns ",
+        "SX (Rights Owner)": [
+          "N/A"
+        ],
+        "SX (Artist)": [
+          "Claimed"
+        ]
+      }
+    },
+    {
+      "id": "recTzO38mlOqygW9D",
+      "fields": {
+        "Name": "Merry Christmas ",
+        "Notes": "https://open.spotify.com/album/3RfMfyPLea5WD7lk0SpSXd?si=TexcLUEgTnm396FldEVJdg",
+        "Album": "Merry Christmas",
+        "SX (Rights Owner)": [
+          "N/A"
+        ],
+        "SX (Artist)": [
+          "Needs to be Submitted by RO"
+        ]
+      }
+    },
+    {
+      "id": "recneBwCYKIqvluxJ",
+      "fields": {
+        "Name": "White Christmas ",
+        "Album": "Merry Christmas",
+        "SX (Rights Owner)": [
+          "N/A"
+        ],
+        "SX (Artist)": [
+          "Needs to be Submitted by RO"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Delete Records
+
+**Endpoint:** `DELETE /v0/appEurfA8kXQE3slK/registration%20project%20(soundexchange)`
+
+To delete REGISTRATION PROJECT (SOUNDEXCHANGE) records, issue a DELETE request to the REGISTRATION PROJECT (SOUNDEXCHANGE) endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request should include a URL-encoded array of up to 10 record IDs to delete.
+
+```bash
+curl -X DELETE https://api.airtable.com/v0/appEurfA8kXQE3slK/REGISTRATION%20PROJECT%20(SOUNDEXCHANGE) \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -G \
+  --data-urlencode 'records[]=recj1SM8RsYu6EXq6' \
+  --data-urlencode 'records[]=recTzO38mlOqygW9D'
+```
+

--- a/DOCS/AIRTABLE_API/releases.md
+++ b/DOCS/AIRTABLE_API/releases.md
@@ -1,0 +1,367 @@
+# Releases
+
+**Table ID:** `tbl7rjVKUd5faZ7fV`  
+**Base ID:** `appEurfA8kXQE3slK`
+
+---
+
+## Fields
+
+| Field Name                                    | Field ID            | Type                   | Description                                                                      |
+| --------------------------------------------- | ------------------- | ---------------------- | -------------------------------------------------------------------------------- |
+| Release Title                                 | `fldsx6jLQOHSmfJCI` | Text                   | A single line of text.                                                           |
+| Notes                                         | `fldksOSzD9KkWK2b7` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| Release Format                                | `fldpUtbW55MIoAsPI` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Release Date                                  | `fldqw7pfMyILlCUOj` | Text                   | A single line of text.                                                           |
+| Box Spreadsheet                               | `fldzdxIcLkb2nqoWX` | URL                    | A valid URL (e.g. airtable.com or https://airtable.com/universe).                |
+| Released                                      | `fld5KNa9xmEDkR4qu` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Distributed                                   | `fld9aThxEU6kwU1z0` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Recordings                                    | `fldcrSUSKSeL84t0N` | Link to another record | Array of linked records IDs from the Recordings table.                           |
+| Compositions                                  | `fldy0DXSoqbUN1LXl` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Primary Artist                                | `fldyz0BJ21bNKgFcK` | Link to another record | Array of linked records IDs from the Artists table.                              |
+| Featured Artist(s)                            | `fldvYrNxuyvpDgksg` | Link to another record | Array of linked records IDs from the Artists table.                              |
+| Genre                                         | `fldS7r2NGoS2jydpf` | Multiple select        | Array of selected option names. When creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Compilation                                   | `fldcuqaeNTj3aLWko` | Checkbox               | This field is "true" when checked and otherwise empty.                           |
+| Original release label                        | `fld9sglzyDRTWE3qk` | Link to another record | Array of linked records IDs from the Master Owners table.                        |
+| Current release label                         | `fldilpa7qfgWZwxH6` | Link to another record | Array of linked records IDs from the Master Owners table.                        |
+| Duration                                      | `fldBFhY41oP8XVvz1` | Duration               | An integer representing number of seconds. This field allows negative and positive numbers. |
+| UPC                                           | `fldw5dtUdEQQhxeFH` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| Masters                                       | `fldHGNs3UFZyS4N1k` | Text                   | A single line of text.                                                           |
+| DISCO                                         | `fldJ767pHALKzAAFp` | URL                    | A valid URL (e.g. airtable.com or https://airtable.com/universe).                |
+| Artwork                                       | `fldN9bkYwXM8YlGqy` | URL                    | A valid URL (e.g. airtable.com or https://airtable.com/universe).                |
+| Spotify                                       | `fldyPJUzAYj78CDW5` | Text                   | A single line of text.                                                           |
+| Apple Music                                   | `fldNXcwqmK6KxZu0N` | Text                   | A single line of text.                                                           |
+| Amazon Music                                  | `fld8B1PzcUHHl34c4` | Text                   | A single line of text.                                                           |
+| YouTube Music                                 | `fldpt4NEmhixMw5B6` | Text                   | A single line of text.                                                           |
+| Soundcloud                                    | `fld3DwnQjzmi8jIDO` | Text                   | A single line of text.                                                           |
+| Songwhip                                      | `fldfKvFLPOzxubh6Z` | Text                   | A single line of text.                                                           |
+| Music Licensing Agreements                    | `fldb5Jx5eJYWHjw2k` | Text                   | A single line of text.                                                           |
+| [DON'T DELETE] Original Release in Recordings | `fld1Mh5OoA23r4nGm` | Link to another record | Array of linked records IDs from the Recordings table.                           |
+| Spotify URI                                   | `fldvHGEbjgs0HoBt1` | Text                   | A single line of text.                                                           |
+| SPOTIFY *                                     | `fldKK8EPwWerOzv7C` | Checkbox               | This field is "true" when checked and otherwise empty.                           |
+| APPLE MUSIC *                                 | `fldUjQsL6u8BYLNz1` | Checkbox               | This field is "true" when checked and otherwise empty.                           |
+| Status                                        | `fldPWSyA8gZoaOS5p` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Compositions 2                                | `flds3xoOLuDcoO9XQ` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 3                                | `fldJM2AZnEXwFIW3p` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Chevy Showroom Dist Mgmt                      | `fldbLdqXtUapQ8JBh` | Link to another record | Array of linked records IDs from the Chevy Showroom Dist Mgmt table.             |
+| Chevy Showroom Dist Mgmt copy                 | `fldRV7K5PdgwSG7jf` | Text                   | A single line of text.                                                           |
+| APM Dist Mgmt                                 | `fldI26ZqCc65BoOrm` | Link to another record | Array of linked records IDs from the APM Dist Mgmt table.                        |
+| Legal Docs                                    | `fldQdqUgXLYutGCKD` | Link to another record | Array of linked records IDs from the Legal Docs table.                           |
+| PROGRESS REPORT                               | `fldwzhPADkBeZeAhk` | Link to another record | Array of linked records IDs from the PROGRESS REPORT table.                      |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/releases`
+
+To list records in Releases , issue a GET request to the Releases endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Returned records do not include any fields with "empty" values, e.g. "" , [] , or false .
+
+```bash
+curl "https://api.airtable.com/v0/appEurfA8kXQE3slK/Releases?maxRecords=3&view=Default" \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+### Query Parameters
+
+| Parameter               | Type             | Required   | Description                                                                      |
+| ----------------------- | ---------------- | ---------- | -------------------------------------------------------------------------------- |
+| `fields`                | array of strings | optional   | Only data for fields whose names are in this list will be included in the result. If you don't need every field, you can use this parameter to reduce the amount of data transferred. For example, to only return data from Release Title and Notes , send these two query parameters: fields%5B%5D=Release% |
+| `filterByFormula`       | string           | optional   | A formula used to filter records. The formula will be evaluated for each record, and if the result is not 0 , false , "" , NaN , [] , or #Error! the record will be included in the response. We recommend testing your formula in the Formula field UI before using it in your API request. If combined wit |
+| `maxRecords`            | number           | optional   | The maximum total number of records that will be returned in your requests. If this value is larger than pageSize (which is 100 by default), you may have to load multiple pages to reach this total. See the Pagination section below for more. |
+| `pageSize`              | number           | optional   | The number of records returned in each request. Must be less than or equal to 100. Default is 100. See the Pagination section below for more. |
+| `sort`                  | array of objects | optional   | A list of sort objects that specifies how the records will be ordered. Each sort object must have a field key specifying the name of the field to sort on, and an optional direction key that is either "asc" or "desc" . The default direction is "asc" . The sort parameter overrides the sorting of the v |
+| `view`                  | string           | optional   | The name or ID of a view in the Releases table. If set, only the records in that view will be returned. The records will be sorted according to the order of the view unless the sort parameter is included, which overrides that order. Fields hidden in this view will be returned in the results. To only |
+| `cellFormat`            | string           | optional   | The format that should be used for cell values. Supported values are: json : cells will be formatted as JSON, depending on the field type. string : cells will be formatted as user-facing strings, regardless of the field type. The timeZone and userLocale parameters are required when using string as t |
+| `timeZone`              | string           | optional   | The time zone that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `userLocale`            | string           | optional   | The user locale that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `returnFieldsByFieldId` | boolean          | optional   | An optional boolean value that lets you return field objects where the key is the field id. This defaults to false , which returns field objects where the key is the field name. |
+| `recordMetadata`        | array of strings | optional   | An optional field that, if includes commentCount , adds a commentCount read only property on each record returned. |
+
+---
+
+## Retrieve a Record
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/releases`
+
+To retrieve an existing record in Releases table, issue a GET request to the record endpoint.
+
+Any "empty" fields (e.g. "" , [] , or false ) in the record will not be returned.
+
+```bash
+curl https://api.airtable.com/v0/appEurfA8kXQE3slK/Releases/recTz2l2QLmFcZybo \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+---
+
+## Create Records
+
+**Endpoint:** `POST /v0/appEurfA8kXQE3slK/releases`
+
+To create new records, issue a POST request to the Releases endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have one key whose value is an inner object containing your record's cell values, keyed by either field name or field id.
+
+```bash
+curl -X POST https://api.airtable.com/v0/appEurfA8kXQE3slK/Releases \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "fields": {
+        "Release Title": "'\''Twixt Twelve And Twenty",
+        "Release Format": "Single",
+        "Release Date": "1959",
+        "Released": "✅",
+        "Recordings": [
+          "recNdzEdsnw9pSp7P"
+        ],
+        "Primary Artist": [
+          "recLWgt9qnlgDkkAo"
+        ],
+        "Original release label": [
+          "recFsgtFh5ff9SxTo"
+        ],
+        "Current release label": [
+          "recxETJc1dhJT192X"
+        ],
+        "[DON'\''T DELETE] Original Release in Recordings": [
+          "recNdzEdsnw9pSp7P"
+        ]
+      }
+    },
+    {
+      "fields": {
+        "Release Title": "\"Collectors Item!\".....",
+        "Notes": "Need composition info.",
+        "Release Format": "LP",
+        "Recordings": [
+          "recoy9gU6P75JEj2d",
+          "recnn6iNucTLnL4uf",
+          "rec1OKGgRQ0BCXrc7",
+          "rec3PoXs8dmLnvdev",
+          "recAtcLfX2y96Aqv5",
+          "recR3NQ5LmFazAAxK",
+          "reclCb8oTdgmDLG4N",
+          "recZXs1cbXqDVA7go",
+          "recdfPQRd6qye4zlg",
+          "recU2j7h9qoyOAxWw",
+          "rectCUAEJ4m3Ga7Ml",
+          "recm72o9uQRTFVk0m",
+          "recAVFp7WNaDyQ91Z",
+          "rec29M114hJId6Q5Q",
+          "recRDSPpJBjW3ulUn",
+          "rec4F2huLpXYuRqwF",
+          "recCHGNw8cqkwKZh8",
+          "recwbBOzNj0exlq8I",
+          "recQF1cqvOjt4BAGs",
+          "rec9UxBtaE8THcAni",
+          "recEc3zlfdh1OmtlY",
+          "recp72PKiF1ALw4Zr",
+          "reczJYTYR1GXUW8U8",
+          "recU9fiea431oIdl6",
+          "recYBqwLLYkHz8rAa",
+          "recqzM5CBFDZ2dcSK",
+          "rec8oCNJ3dGJS6uLl",
+          "recpSSfce6HlQNxrT",
+          "recMZphXjO4PDLSrb",
+          "rec4YfNgcWkEDxUBE",
+          "recehsVD9XIW3Wmtu",
+          "rec3W1E5G8uRJef7O",
+          "recN2sL3YEF4zJa3s",
+          "recSN0ECJxTAujxDP",
+          "recFsFQYbETSxkIXJ",
+          "recBcMi76DaSozRcW",
+          "recZ9ujzgGhwXRg1p",
+          "recZnY89zmsBDhYeF",
+          "rece8AdAyQ2Tqjc81",
+          "recSFt7zRlveVxSw3"
+        ],
+        "Primary Artist": [
+          "recankA8Ox6RB2SlP",
+          "rec2QLgAKOvV27OzX"
+        ],
+        "Original release label": [
+          "rec52XnBYFVE0RgZ8"
+        ],
+        "Current release label": [
+          "rec52XnBYFVE0RgZ8"
+        ],
+        "Status": "In progress"
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Update / Upsert Records
+
+**Endpoint:** `PATCH /v0/appEurfA8kXQE3slK/releases`
+
+To update Releases records, issue a request to the Releases endpoint. Table names and table IDs can be used interchangeably. Using table IDs means table name changes won't require modifying your API request code. A PATCH request will only update the fields included in the request. Fields not included in the request will be unchanged. A PUT request will perform a destructive update and clear all unincluded cell values.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have an id property representing the record ID and a fields property which contains all of your record's cell values by field name or field id for all of your record's cell values by field name.
+
+```bash
+curl -X PATCH https://api.airtable.com/v0/appEurfA8kXQE3slK/Releases \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "id": "recTz2l2QLmFcZybo",
+      "fields": {
+        "Release Title": "'\''Twixt Twelve And Twenty",
+        "Release Format": "Single",
+        "Release Date": "1959",
+        "Released": "✅",
+        "Recordings": [
+          "recNdzEdsnw9pSp7P"
+        ],
+        "Primary Artist": [
+          "recLWgt9qnlgDkkAo"
+        ],
+        "Original release label": [
+          "recFsgtFh5ff9SxTo"
+        ],
+        "Current release label": [
+          "recxETJc1dhJT192X"
+        ],
+        "[DON'\''T DELETE] Original Release in Recordings": [
+          "recNdzEdsnw9pSp7P"
+        ]
+      }
+    },
+    {
+      "id": "rec6Kwae7S2JToPqT",
+      "fields": {
+        "Release Title": "\"Collectors Item!\".....",
+        "Notes": "Need composition info.",
+        "Release Format": "LP",
+        "Recordings": [
+          "recoy9gU6P75JEj2d",
+          "recnn6iNucTLnL4uf",
+          "rec1OKGgRQ0BCXrc7",
+          "rec3PoXs8dmLnvdev",
+          "recAtcLfX2y96Aqv5",
+          "recR3NQ5LmFazAAxK",
+          "reclCb8oTdgmDLG4N",
+          "recZXs1cbXqDVA7go",
+          "recdfPQRd6qye4zlg",
+          "recU2j7h9qoyOAxWw",
+          "rectCUAEJ4m3Ga7Ml",
+          "recm72o9uQRTFVk0m",
+          "recAVFp7WNaDyQ91Z",
+          "rec29M114hJId6Q5Q",
+          "recRDSPpJBjW3ulUn",
+          "rec4F2huLpXYuRqwF",
+          "recCHGNw8cqkwKZh8",
+          "recwbBOzNj0exlq8I",
+          "recQF1cqvOjt4BAGs",
+          "rec9UxBtaE8THcAni",
+          "recEc3zlfdh1OmtlY",
+          "recp72PKiF1ALw4Zr",
+          "reczJYTYR1GXUW8U8",
+          "recU9fiea431oIdl6",
+          "recYBqwLLYkHz8rAa",
+          "recqzM5CBFDZ2dcSK",
+          "rec8oCNJ3dGJS6uLl",
+          "recpSSfce6HlQNxrT",
+          "recMZphXjO4PDLSrb",
+          "rec4YfNgcWkEDxUBE",
+          "recehsVD9XIW3Wmtu",
+          "rec3W1E5G8uRJef7O",
+          "recN2sL3YEF4zJa3s",
+          "recSN0ECJxTAujxDP",
+          "recFsFQYbETSxkIXJ",
+          "recBcMi76DaSozRcW",
+          "recZ9ujzgGhwXRg1p",
+          "recZnY89zmsBDhYeF",
+          "rece8AdAyQ2Tqjc81",
+          "recSFt7zRlveVxSw3"
+        ],
+        "Primary Artist": [
+          "recankA8Ox6RB2SlP",
+          "rec2QLgAKOvV27OzX"
+        ],
+        "Original release label": [
+          "rec52XnBYFVE0RgZ8"
+        ],
+        "Current release label": [
+          "rec52XnBYFVE0RgZ8"
+        ],
+        "Status": "In progress"
+      }
+    },
+    {
+      "id": "recfaJhsp62BjNTJ8",
+      "fields": {
+        "Release Title": "\"Pat\" On Mike",
+        "Release Format": "EP",
+        "Release Date": "1956",
+        "Released": "✅",
+        "Distributed": "✅",
+        "Recordings": [
+          "recX3sh3XCtrGhkoA",
+          "recIX5VexbWGumTw5",
+          "recAG5dZXsdwBFcWi",
+          "recMtZ6O85laVmPbJ"
+        ],
+        "Compositions": [
+          "recthVEausP4bIvPg",
+          "recY79hfzdKhSuIub",
+          "recAxHhL2AFyBuECH"
+        ],
+        "Primary Artist": [
+          "recLWgt9qnlgDkkAo"
+        ],
+        "Original release label": [
+          "recFsgtFh5ff9SxTo"
+        ],
+        "Current release label": [
+          "recxETJc1dhJT192X"
+        ],
+        "UPC": "00602458125160",
+        "Spotify": "https://open.spotify.com/album/1skBB9oladdmjLeaaqenIy",
+        "Apple Music": "https://music.apple.com/us/album/pat-on-mike-ep/1696216346",
+        "Amazon Music": "https://music.amazon.com/albums/B0CCHMC7Y8?marketplaceId=ATVPDKIKX0DER&musicTerritory=US&ref=dm_sh_DuSuCiYoi3IIECEsJ3vf8wMNw",
+        "YouTube Music": "https://music.youtube.com/playlist?list=OLAK5uy_kcQSPsAyRkccgLLpCmjn0IDjeCsY-RVaA&feature=share",
+        "Soundcloud": "N/A",
+        "Songwhip": "https://songwhip.com/pat-boone/pat-on-mike",
+        "[DON'\''T DELETE] Original Release in Recordings": [
+          "recX3sh3XCtrGhkoA",
+          "recIX5VexbWGumTw5",
+          "recAG5dZXsdwBFcWi",
+          "recMtZ6O85laVmPbJ"
+        ],
+        "Spotify URI": "1skBB9oladdmjLeaaqenIy"
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Delete Records
+
+**Endpoint:** `DELETE /v0/appEurfA8kXQE3slK/releases`
+
+To delete Releases records, issue a DELETE request to the Releases endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request should include a URL-encoded array of up to 10 record IDs to delete.
+
+```bash
+curl -X DELETE https://api.airtable.com/v0/appEurfA8kXQE3slK/Releases \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -G \
+  --data-urlencode 'records[]=recTz2l2QLmFcZybo' \
+  --data-urlencode 'records[]=rec6Kwae7S2JToPqT'
+```
+

--- a/DOCS/AIRTABLE_API/resources.md
+++ b/DOCS/AIRTABLE_API/resources.md
@@ -1,0 +1,173 @@
+# Resources
+
+**Table ID:** `tblw2UlyAgN2Qp6ev`  
+**Base ID:** `appEurfA8kXQE3slK`
+
+---
+
+## Fields
+
+| Field Name   | Field ID            | Type          | Description                                                                      |
+| ------------ | ------------------- | ------------- | -------------------------------------------------------------------------------- |
+| Resource     | `fldzaWsybLtGXz8eM` | Text          | A single line of text.                                                           |
+| Category     | `fldMTErhCiggVtruz` | Single select | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Description  | `fldYf0MGLdenLIC7O` | Long text     | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| Link         | `fldPvCrGK0HU82Xrf` | URL           | A valid URL (e.g. airtable.com or https://airtable.com/universe).                |
+| Email        | `fldtonTwYqxIGPch2` | Email         | A valid email address.                                                           |
+| Username     | `fldpRg1Rzkp9VHxZB` | Text          | A single line of text.                                                           |
+| Password     | `fldU3aExVDOeHmrf0` | Text          | A single line of text.                                                           |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/resources`
+
+To list records in Resources , issue a GET request to the Resources endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Returned records do not include any fields with "empty" values, e.g. "" , [] , or false .
+
+```bash
+curl "https://api.airtable.com/v0/appEurfA8kXQE3slK/Resources?maxRecords=3&view=Default" \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+### Query Parameters
+
+| Parameter               | Type             | Required   | Description                                                                      |
+| ----------------------- | ---------------- | ---------- | -------------------------------------------------------------------------------- |
+| `fields`                | array of strings | optional   | Only data for fields whose names are in this list will be included in the result. If you don't need every field, you can use this parameter to reduce the amount of data transferred. For example, to only return data from Resource and Category , send these two query parameters: fields%5B%5D=Resource&f |
+| `filterByFormula`       | string           | optional   | A formula used to filter records. The formula will be evaluated for each record, and if the result is not 0 , false , "" , NaN , [] , or #Error! the record will be included in the response. We recommend testing your formula in the Formula field UI before using it in your API request. If combined wit |
+| `maxRecords`            | number           | optional   | The maximum total number of records that will be returned in your requests. If this value is larger than pageSize (which is 100 by default), you may have to load multiple pages to reach this total. See the Pagination section below for more. |
+| `pageSize`              | number           | optional   | The number of records returned in each request. Must be less than or equal to 100. Default is 100. See the Pagination section below for more. |
+| `sort`                  | array of objects | optional   | A list of sort objects that specifies how the records will be ordered. Each sort object must have a field key specifying the name of the field to sort on, and an optional direction key that is either "asc" or "desc" . The default direction is "asc" . The sort parameter overrides the sorting of the v |
+| `view`                  | string           | optional   | The name or ID of a view in the Resources table. If set, only the records in that view will be returned. The records will be sorted according to the order of the view unless the sort parameter is included, which overrides that order. Fields hidden in this view will be returned in the results. To onl |
+| `cellFormat`            | string           | optional   | The format that should be used for cell values. Supported values are: json : cells will be formatted as JSON, depending on the field type. string : cells will be formatted as user-facing strings, regardless of the field type. The timeZone and userLocale parameters are required when using string as t |
+| `timeZone`              | string           | optional   | The time zone that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `userLocale`            | string           | optional   | The user locale that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `returnFieldsByFieldId` | boolean          | optional   | An optional boolean value that lets you return field objects where the key is the field id. This defaults to false , which returns field objects where the key is the field name. |
+| `recordMetadata`        | array of strings | optional   | An optional field that, if includes commentCount , adds a commentCount read only property on each record returned. |
+
+---
+
+## Retrieve a Record
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/resources`
+
+To retrieve an existing record in Resources table, issue a GET request to the record endpoint.
+
+Any "empty" fields (e.g. "" , [] , or false ) in the record will not be returned.
+
+```bash
+curl https://api.airtable.com/v0/appEurfA8kXQE3slK/Resources/reci5Vu3zuaEni0dw \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+---
+
+## Create Records
+
+**Endpoint:** `POST /v0/appEurfA8kXQE3slK/resources`
+
+To create new records, issue a POST request to the Resources endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have one key whose value is an inner object containing your record's cell values, keyed by either field name or field id.
+
+```bash
+curl -X POST https://api.airtable.com/v0/appEurfA8kXQE3slK/Resources \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "fields": {
+        "Resource": "Airtable",
+        "Description": "Internal Digital Database ",
+        "Link": "airtable.com",
+        "Email": "pbglpubl@gmail.com",
+        "Username": "pbglpubl@gmail.com",
+        "Password": "Apr219552Hearts2Kisses!"
+      }
+    },
+    {
+      "fields": {
+        "Resource": "AllMusic",
+        "Category": "Database",
+        "Description": "Music Credits Database",
+        "Link": "https://www.allmusic.com/"
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Update / Upsert Records
+
+**Endpoint:** `PATCH /v0/appEurfA8kXQE3slK/resources`
+
+To update Resources records, issue a request to the Resources endpoint. Table names and table IDs can be used interchangeably. Using table IDs means table name changes won't require modifying your API request code. A PATCH request will only update the fields included in the request. Fields not included in the request will be unchanged. A PUT request will perform a destructive update and clear all unincluded cell values.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have an id property representing the record ID and a fields property which contains all of your record's cell values by field name or field id for all of your record's cell values by field name.
+
+```bash
+curl -X PATCH https://api.airtable.com/v0/appEurfA8kXQE3slK/Resources \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "id": "reci5Vu3zuaEni0dw",
+      "fields": {
+        "Resource": "Airtable",
+        "Description": "Internal Digital Database ",
+        "Link": "airtable.com",
+        "Email": "pbglpubl@gmail.com",
+        "Username": "pbglpubl@gmail.com",
+        "Password": "Apr219552Hearts2Kisses!"
+      }
+    },
+    {
+      "id": "rect3gYOUE2qnzq0i",
+      "fields": {
+        "Resource": "AllMusic",
+        "Category": "Database",
+        "Description": "Music Credits Database",
+        "Link": "https://www.allmusic.com/"
+      }
+    },
+    {
+      "id": "recMfCI9Z5dJMqjHn",
+      "fields": {
+        "Resource": "APM Library Portal",
+        "Category": "Database",
+        "Description": "APM Library ",
+        "Link": "https://libraryportal.apmmusic.com/Home",
+        "Email": "craftbrewzmusic@gmail.com",
+        "Username": "craftbrewzmusic@gmail.com",
+        "Password": "Mixolydianmob2025!"
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Delete Records
+
+**Endpoint:** `DELETE /v0/appEurfA8kXQE3slK/resources`
+
+To delete Resources records, issue a DELETE request to the Resources endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request should include a URL-encoded array of up to 10 record IDs to delete.
+
+```bash
+curl -X DELETE https://api.airtable.com/v0/appEurfA8kXQE3slK/Resources \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -G \
+  --data-urlencode 'records[]=reci5Vu3zuaEni0dw' \
+  --data-urlencode 'records[]=rect3gYOUE2qnzq0i'
+```
+

--- a/DOCS/AIRTABLE_API/scratch.md
+++ b/DOCS/AIRTABLE_API/scratch.md
@@ -1,0 +1,151 @@
+# SCRATCH
+
+**Table ID:** `tblrAq8as4L09NmHw`  
+**Base ID:** `appEurfA8kXQE3slK`
+
+---
+
+## Fields
+
+| Field Name       | Field ID            | Type   | Description            |
+| ---------------- | ------------------- | ------ | ---------------------- |
+| Name             | `fld74ysLPUTWeo1JJ` | Text   | A single line of text. |
+| ISWC_Single_Line | `fldbU8hBkzps4HUqC` | Text   | A single line of text. |
+| ASCAP_Work_ID    | `fldofwEa2KwQsKyOf` | Text   | A single line of text. |
+| BMI_Work_ID      | `fld0yFOz5xBqzY8k9` | Text   | A single line of text. |
+| MLC_Song_Code    | `fldFDQ0kWsUt3y1Mm` | Text   | A single line of text. |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/scratch`
+
+To list records in SCRATCH , issue a GET request to the SCRATCH endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Returned records do not include any fields with "empty" values, e.g. "" , [] , or false .
+
+```bash
+curl "https://api.airtable.com/v0/appEurfA8kXQE3slK/SCRATCH?maxRecords=3&view=Grid%20view" \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+### Query Parameters
+
+| Parameter               | Type             | Required   | Description                                                                      |
+| ----------------------- | ---------------- | ---------- | -------------------------------------------------------------------------------- |
+| `fields`                | array of strings | optional   | Only data for fields whose names are in this list will be included in the result. If you don't need every field, you can use this parameter to reduce the amount of data transferred. For example, to only return data from Name and ISWC_Single_Line , send these two query parameters: fields%5B%5D=Name&f |
+| `filterByFormula`       | string           | optional   | A formula used to filter records. The formula will be evaluated for each record, and if the result is not 0 , false , "" , NaN , [] , or #Error! the record will be included in the response. We recommend testing your formula in the Formula field UI before using it in your API request. If combined wit |
+| `maxRecords`            | number           | optional   | The maximum total number of records that will be returned in your requests. If this value is larger than pageSize (which is 100 by default), you may have to load multiple pages to reach this total. See the Pagination section below for more. |
+| `pageSize`              | number           | optional   | The number of records returned in each request. Must be less than or equal to 100. Default is 100. See the Pagination section below for more. |
+| `sort`                  | array of objects | optional   | A list of sort objects that specifies how the records will be ordered. Each sort object must have a field key specifying the name of the field to sort on, and an optional direction key that is either "asc" or "desc" . The default direction is "asc" . The sort parameter overrides the sorting of the v |
+| `view`                  | string           | optional   | The name or ID of a view in the SCRATCH table. If set, only the records in that view will be returned. The records will be sorted according to the order of the view unless the sort parameter is included, which overrides that order. Fields hidden in this view will be returned in the results. To only |
+| `cellFormat`            | string           | optional   | The format that should be used for cell values. Supported values are: json : cells will be formatted as JSON, depending on the field type. string : cells will be formatted as user-facing strings, regardless of the field type. The timeZone and userLocale parameters are required when using string as t |
+| `timeZone`              | string           | optional   | The time zone that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `userLocale`            | string           | optional   | The user locale that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `returnFieldsByFieldId` | boolean          | optional   | An optional boolean value that lets you return field objects where the key is the field id. This defaults to false , which returns field objects where the key is the field name. |
+| `recordMetadata`        | array of strings | optional   | An optional field that, if includes commentCount , adds a commentCount read only property on each record returned. |
+
+---
+
+## Retrieve a Record
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/scratch`
+
+To retrieve an existing record in SCRATCH table, issue a GET request to the record endpoint.
+
+Any "empty" fields (e.g. "" , [] , or false ) in the record will not be returned.
+
+```bash
+curl https://api.airtable.com/v0/appEurfA8kXQE3slK/SCRATCH/recfJKbIMvRr6z58y \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+---
+
+## Create Records
+
+**Endpoint:** `POST /v0/appEurfA8kXQE3slK/scratch`
+
+To create new records, issue a POST request to the SCRATCH endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have one key whose value is an inner object containing your record's cell values, keyed by either field name or field id.
+
+```bash
+curl -X POST https://api.airtable.com/v0/appEurfA8kXQE3slK/SCRATCH \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "fields": {
+        "Name": "PART OF AMERICA DIED",
+        "ISWC_Single_Line": "T3178280401",
+        "ASCAP_Work_ID": "920267575,931319904",
+        "MLC_Song_Code": "PJ77RV"
+      }
+    },
+    {
+      "fields": {
+        "Name": "PLENTY OF REASONS",
+        "ISWC_Single_Line": "T9059967372,T7024414266"
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Update / Upsert Records
+
+**Endpoint:** `PATCH /v0/appEurfA8kXQE3slK/scratch`
+
+To update SCRATCH records, issue a request to the SCRATCH endpoint. Table names and table IDs can be used interchangeably. Using table IDs means table name changes won't require modifying your API request code. A PATCH request will only update the fields included in the request. Fields not included in the request will be unchanged. A PUT request will perform a destructive update and clear all unincluded cell values.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have an id property representing the record ID and a fields property which contains all of your record's cell values by field name or field id for all of your record's cell values by field name.
+
+```bash
+curl -X PATCH https://api.airtable.com/v0/appEurfA8kXQE3slK/SCRATCH \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "id": "recfJKbIMvRr6z58y",
+      "fields": {
+        "Name": "PART OF AMERICA DIED",
+        "ISWC_Single_Line": "T3178280401",
+        "ASCAP_Work_ID": "920267575,931319904",
+        "MLC_Song_Code": "PJ77RV"
+      }
+    },
+    {
+      "id": "recGUiwCPj2Vmrao2",
+      "fields": {
+        "Name": "PLENTY OF REASONS",
+        "ISWC_Single_Line": "T9059967372,T7024414266"
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Delete Records
+
+**Endpoint:** `DELETE /v0/appEurfA8kXQE3slK/scratch`
+
+To delete SCRATCH records, issue a DELETE request to the SCRATCH endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request should include a URL-encoded array of up to 10 record IDs to delete.
+
+```bash
+curl -X DELETE https://api.airtable.com/v0/appEurfA8kXQE3slK/SCRATCH \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -G \
+  --data-urlencode 'records[]=recfJKbIMvRr6z58y' \
+  --data-urlencode 'records[]=recGUiwCPj2Vmrao2'
+```
+

--- a/DOCS/AIRTABLE_API/songwriters.md
+++ b/DOCS/AIRTABLE_API/songwriters.md
@@ -1,0 +1,237 @@
+# Songwriters
+
+**Table ID:** `tbl2KLh2RIrS5AmSX`  
+**Base ID:** `appEurfA8kXQE3slK`
+
+---
+
+## Fields
+
+| Field Name                  | Field ID            | Type                   | Description                                                                      |
+| --------------------------- | ------------------- | ---------------------- | -------------------------------------------------------------------------------- |
+| Name as listed in PRO       | `fld50qVly0wjnxL8t` | Formula                | Computed value: { Last Name } & " " & { Suffix } & " " & { First Name } & " " & { Middle Name } & " " & { Interested Party } . |
+| IPI Number                  | `fld712K46CgGyjAEQ` | Text                   | A single line of text.                                                           |
+| Verified name, PRO, and IPI | `fldvOqKgfAWZZhZ0d` | Checkbox               | This field is "true" when checked and otherwise empty.                           |
+| Notes                       | `fldgYC4IjCcx77VKU` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| First Name                  | `fldynnsFy2uSBpifH` | Text                   | A single line of text.                                                           |
+| Middle Name                 | `fldUbHMnW5KnLRPh6` | Text                   | A single line of text.                                                           |
+| Last Name                   | `fldo5pT323Fg9vrvX` | Text                   | A single line of text.                                                           |
+| Suffix                      | `fldxUR55wBw9jclxS` | Text                   | A single line of text.                                                           |
+| Interested Party            | `fld5Zt8QYRPNL1wpC` | Text                   | A single line of text.                                                           |
+| Alias(es) in PRO            | `fldsNiY7FUJjvSEd8` | Long text              | Multiple lines of text, which may contain "mention tokens", e.g. <airtable:mention id="menE1i9oBaGX3DseR">@Alex</airtable:mention> |
+| PRO Affiliation             | `fldj2bMLt8EY2yPAM` | Single select          | Selected option name. When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match. |
+| Compositions                | `fldEoEyYlIjaKwrkq` | Link to another record | Array of linked records IDs from the Compositions table. Because this field is configured to show records in reversed order, the order of records in the app will be reversed compared to what you see here. |
+| Published by                | `fld5mmxZv286NzYCs` | Link to another record | Array of linked records IDs from the Publishers table.                           |
+| Legal Docs                  | `fldwccASH977BT3le` | Link to another record | Array of linked records IDs from the Legal Docs table.                           |
+| Compositions 2              | `fld0bWrdHt8Z8ONQz` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 3              | `fldwlANx0ME3oq8Ir` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 4              | `fld9gU0iajX6WkAXL` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 5              | `fldYlChRBjIjrCR1V` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 6              | `fldT9yT04PWmi7p1T` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 7              | `fld28DiKnKlCMG76H` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 8              | `fld06Logrgm1PYtJO` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 7 copy         | `fldKl1LiSp8T5mJIT` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+| Compositions 7 copy copy    | `fldSdlzArrF30VgBR` | Link to another record | Array of linked records IDs from the Compositions table.                         |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/songwriters`
+
+To list records in Songwriters , issue a GET request to the Songwriters endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Returned records do not include any fields with "empty" values, e.g. "" , [] , or false .
+
+```bash
+curl "https://api.airtable.com/v0/appEurfA8kXQE3slK/Songwriters?maxRecords=3&view=Default" \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+### Query Parameters
+
+| Parameter               | Type             | Required   | Description                                                                      |
+| ----------------------- | ---------------- | ---------- | -------------------------------------------------------------------------------- |
+| `fields`                | array of strings | optional   | Only data for fields whose names are in this list will be included in the result. If you don't need every field, you can use this parameter to reduce the amount of data transferred. For example, to only return data from Name as listed in PRO and IPI Number , send these two query parameters: fields%5 |
+| `filterByFormula`       | string           | optional   | A formula used to filter records. The formula will be evaluated for each record, and if the result is not 0 , false , "" , NaN , [] , or #Error! the record will be included in the response. We recommend testing your formula in the Formula field UI before using it in your API request. If combined wit |
+| `maxRecords`            | number           | optional   | The maximum total number of records that will be returned in your requests. If this value is larger than pageSize (which is 100 by default), you may have to load multiple pages to reach this total. See the Pagination section below for more. |
+| `pageSize`              | number           | optional   | The number of records returned in each request. Must be less than or equal to 100. Default is 100. See the Pagination section below for more. |
+| `sort`                  | array of objects | optional   | A list of sort objects that specifies how the records will be ordered. Each sort object must have a field key specifying the name of the field to sort on, and an optional direction key that is either "asc" or "desc" . The default direction is "asc" . The sort parameter overrides the sorting of the v |
+| `view`                  | string           | optional   | The name or ID of a view in the Songwriters table. If set, only the records in that view will be returned. The records will be sorted according to the order of the view unless the sort parameter is included, which overrides that order. Fields hidden in this view will be returned in the results. To o |
+| `cellFormat`            | string           | optional   | The format that should be used for cell values. Supported values are: json : cells will be formatted as JSON, depending on the field type. string : cells will be formatted as user-facing strings, regardless of the field type. The timeZone and userLocale parameters are required when using string as t |
+| `timeZone`              | string           | optional   | The time zone that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `userLocale`            | string           | optional   | The user locale that should be used to format dates when using string as the cellFormat . This parameter is required when using string as the cellFormat . |
+| `returnFieldsByFieldId` | boolean          | optional   | An optional boolean value that lets you return field objects where the key is the field id. This defaults to false , which returns field objects where the key is the field name. |
+| `recordMetadata`        | array of strings | optional   | An optional field that, if includes commentCount , adds a commentCount read only property on each record returned. |
+
+---
+
+## Retrieve a Record
+
+**Endpoint:** `GET /v0/appEurfA8kXQE3slK/songwriters`
+
+To retrieve an existing record in Songwriters table, issue a GET request to the record endpoint.
+
+Any "empty" fields (e.g. "" , [] , or false ) in the record will not be returned.
+
+```bash
+curl https://api.airtable.com/v0/appEurfA8kXQE3slK/Songwriters/recJThUCbUnwEm0IO \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
+```
+
+---
+
+## Create Records
+
+**Endpoint:** `POST /v0/appEurfA8kXQE3slK/songwriters`
+
+To create new records, issue a POST request to the Songwriters endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have one key whose value is an inner object containing your record's cell values, keyed by either field name or field id.
+
+```bash
+curl -X POST https://api.airtable.com/v0/appEurfA8kXQE3slK/Songwriters \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "fields": {
+        "IPI Number": "65258",
+        "First Name": "LEE",
+        "Middle Name": "ROY",
+        "Last Name": "ABERNATHY",
+        "Alias(es) in PRO": "N/A",
+        "PRO Affiliation": "ASCAP",
+        "Compositions": [
+          "recjZgKFuQMkWrrah"
+        ],
+        "Published by": [
+          "rec2zj4SHT72jPwBN",
+          "recTseZCQEgXUe8DX"
+        ],
+        "Compositions 2": [
+          "recjZgKFuQMkWrrah"
+        ]
+      }
+    },
+    {
+      "fields": {
+        "IPI Number": "70759",
+        "First Name": "EWART",
+        "Middle Name": "G",
+        "Last Name": "ABNER",
+        "Suffix": "JR",
+        "PRO Affiliation": "BMI",
+        "Compositions": [
+          "recjuzT8JZaQYJMl5"
+        ],
+        "Published by": [
+          "recA8i9RZDhiooJTk"
+        ],
+        "Compositions 2": [
+          "recjuzT8JZaQYJMl5"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Update / Upsert Records
+
+**Endpoint:** `PATCH /v0/appEurfA8kXQE3slK/songwriters`
+
+To update Songwriters records, issue a request to the Songwriters endpoint. Table names and table IDs can be used interchangeably. Using table IDs means table name changes won't require modifying your API request code. A PATCH request will only update the fields included in the request. Fields not included in the request will be unchanged. A PUT request will perform a destructive update and clear all unincluded cell values.
+
+Your request body should include an array of up to 10 record objects. Each of these objects should have an id property representing the record ID and a fields property which contains all of your record's cell values by field name or field id for all of your record's cell values by field name.
+
+```bash
+curl -X PATCH https://api.airtable.com/v0/appEurfA8kXQE3slK/Songwriters \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+  "records": [
+    {
+      "id": "recJThUCbUnwEm0IO",
+      "fields": {
+        "IPI Number": "65258",
+        "First Name": "LEE",
+        "Middle Name": "ROY",
+        "Last Name": "ABERNATHY",
+        "Alias(es) in PRO": "N/A",
+        "PRO Affiliation": "ASCAP",
+        "Compositions": [
+          "recjZgKFuQMkWrrah"
+        ],
+        "Published by": [
+          "rec2zj4SHT72jPwBN",
+          "recTseZCQEgXUe8DX"
+        ],
+        "Compositions 2": [
+          "recjZgKFuQMkWrrah"
+        ]
+      }
+    },
+    {
+      "id": "recDIAhzNYFnleORH",
+      "fields": {
+        "IPI Number": "70759",
+        "First Name": "EWART",
+        "Middle Name": "G",
+        "Last Name": "ABNER",
+        "Suffix": "JR",
+        "PRO Affiliation": "BMI",
+        "Compositions": [
+          "recjuzT8JZaQYJMl5"
+        ],
+        "Published by": [
+          "recA8i9RZDhiooJTk"
+        ],
+        "Compositions 2": [
+          "recjuzT8JZaQYJMl5"
+        ]
+      }
+    },
+    {
+      "id": "recnAbCCLQgZsRFSx",
+      "fields": {
+        "IPI Number": "170362",
+        "First Name": "STANLEY ",
+        "Last Name": "ADAMS",
+        "PRO Affiliation": "ASCAP",
+        "Compositions": [
+          "recwkrj6r5lXKIyXw"
+        ],
+        "Published by": [
+          "recivR09HCpJrhv3y"
+        ],
+        "Compositions 4": [
+          "recwkrj6r5lXKIyXw"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Delete Records
+
+**Endpoint:** `DELETE /v0/appEurfA8kXQE3slK/songwriters`
+
+To delete Songwriters records, issue a DELETE request to the Songwriters endpoint. Note that table names and table ids can be used interchangeably. Using table ids means table name changes do not require modifications to your API request.
+
+Your request should include a URL-encoded array of up to 10 record IDs to delete.
+
+```bash
+curl -X DELETE https://api.airtable.com/v0/appEurfA8kXQE3slK/Songwriters \
+  -H "Authorization: Bearer YOUR_SECRET_API_TOKEN" \
+  -G \
+  --data-urlencode 'records[]=recJThUCbUnwEm0IO' \
+  --data-urlencode 'records[]=recDIAhzNYFnleORH'
+```
+

--- a/DOCS/DEPENDENCIES.md
+++ b/DOCS/DEPENDENCIES.md
@@ -1,0 +1,41 @@
+# Dependencies
+
+This tool is distributed as a Python application, but the dependency chain starts earlier than Python packages alone.
+
+## Dependency Chain
+
+```text
+macOS
+└── Xcode Command Line Tools
+    └── Homebrew (optional but recommended)
+        ├── gh
+        ├── uv
+        │   ├── Python 3.12+
+        │   └── project packages
+        └── git
+            └── AirTable_PBGL repo
+                └── AIRTABLE_API_TOKEN in .env
+```
+
+## Required Runtime Pieces
+
+- `git`: clone, fetch, tag-based updates
+- `uv`: install Python and project dependencies
+- Python 3.12+: runtime for CLI, TUI, and schema tooling
+- `AIRTABLE_API_TOKEN`: required for live Airtable reads and writes
+
+## Project Dependencies
+
+- `typer`: CLI surface
+- `textual`: TUI
+- `requests`: Airtable HTTP client
+- `python-dotenv`: local env loading
+- `beautifulsoup4` and `lxml`: Airtable HTML doc parsing for `atp schema redoc`
+
+## Schema Assets
+
+The app reads committed schema markdown from `DOCS/AIRTABLE_API/`. Those files are regenerated from an Airtable HTML export with:
+
+```bash
+uv run atp schema redoc /path/to/export.html
+```

--- a/DOCS/RELEASING.md
+++ b/DOCS/RELEASING.md
@@ -1,0 +1,24 @@
+# Releasing
+
+Use lightweight tagged releases for teammate distribution.
+
+## Release Flow
+
+1. Ensure tests pass locally.
+2. Commit the intended release state.
+3. Create an annotated version tag.
+4. Push the branch and tag.
+5. Ask teammates to run `./update.sh`.
+
+## Example
+
+```bash
+git tag -a v0.1.0 -m "AirTable PBGL v0.1.0"
+git push origin main --tags
+```
+
+## Notes
+
+- `setup.sh` is for first-time installation.
+- `update.sh` is for existing installs.
+- Keep committed schema markdown current when Airtable metadata changes.

--- a/DOCS/data-model.md
+++ b/DOCS/data-model.md
@@ -1,0 +1,313 @@
+# Gold Label Artists — AirTable Data Model
+
+Reference for all "Link to another record" fields across the 12 active tables. Field IDs are from the AirTable Metadata API; descriptions in quotes are verbatim from the AirTable UI.
+
+---
+
+## 1. The Two Rights Sides
+
+Every piece of recorded music involves two distinct rights stacks. This database's tables map onto them as follows:
+
+| Side | Tables |
+|------|--------|
+| **Recording / Master** | Releases, Recordings, Artists, Master Owners, APM Dist Mgmt, Chevy Showroom Dist Mgmt, PROGRESS REPORT, REGISTRATION PROJECT (SOUNDEXCHANGE) |
+| **Composition / Publishing** | Compositions, Songwriters, Publishers, REGISTRATION PROJECT (PRO +MLC) |
+| **Cross-cutting** | Legal Docs |
+
+---
+
+## 2. Core Ownership Chain
+
+```
+Release ────────────────────── Recording ──────────── Composition ──── Songwriter
+  │                                │                       │                │
+  ├─ Primary Artist                ├─ Primary Artist        ├─ Songwriter 1  └─ Published by ──► Publisher
+  ├─ Featured Artist(s)            ├─ Featured Artist       ├─ Songwriter 2         (Original Pub / Admin Pub / Sub-Pub per slot)
+  ├─ Original release label        ├─ Master Owner 1        └─ Songwriter 3–9
+  └─ Current release label         ├─ Master Owner 2
+       (→ Master Owners)           └─ Master Owner 3
+                                        (→ Master Owners)
+```
+
+**Key rule:** The canonical path from a Release to its underlying Compositions is:
+
+```
+Release → Recordings → Compositions → Songwriters → Publishers
+```
+
+The Releases table also has direct `Compositions` link fields (denormalized shortcut — see §6).
+
+---
+
+## 3. Per-Table Linked Fields
+
+### Releases (`tbl7rjVKUd5faZ7fV`)
+
+| Field | field_id | → Table | Notes |
+|-------|----------|---------|-------|
+| Recordings | `fldcrSUSKSeL84t0N` | Recordings | All recordings on this release |
+| Compositions | `fldy0DXSoqbUN1LXl` | Compositions | Denormalized shortcut; inverse of Compositions.Releases |
+| Compositions 2 | `flds3xoOLuDcoO9XQ` | Compositions | Overflow slot |
+| Compositions 3 | `fldJM2AZnEXwFIW3p` | Compositions | Overflow slot |
+| Primary Artist | `fldyz0BJ21bNKgFcK` | Artists | Exactly one primary credited act |
+| Featured Artist(s) | `fldvYrNxuyvpDgksg` | Artists | Zero or more "feat." acts |
+| Original release label | `fld9sglzyDRTWE3qk` | Master Owners | Master Owner that originally released this |
+| Current release label | `fldilpa7qfgWZwxH6` | Master Owners | Master Owner currently holding the master; see §6 for naming note |
+| [DON'T DELETE] Original Release in Recordings | `fld1Mh5OoA23r4nGm` | Recordings | Auto-generated reverse side of Recordings.Original Release — do not write |
+| Chevy Showroom Dist Mgmt | `fldbLdqXtUapQ8JBh` | Chevy Showroom Dist Mgmt | Distribution records for this release |
+| APM Dist Mgmt | `fldI26ZqCc65BoOrm` | APM Dist Mgmt | Distribution records for this release |
+| Legal Docs | `fldQdqUgXLYutGCKD` | Legal Docs | Agreements covering this release |
+| PROGRESS REPORT | `fldwzhPADkBeZeAhk` | PROGRESS REPORT | Progress tracking entries for this release |
+
+---
+
+### Recordings (`tblESvQQmOBbEXAH0`)
+
+| Field | field_id | → Table | Notes |
+|-------|----------|---------|-------|
+| All Releases | `fld57hhrA0PBM88o6` | Releases | Reverse side of Releases.Recordings |
+| Original Release | `fldV2X7dziu3HDfw8` | Releases | "The first Release that the Recording was featured on" |
+| Compositions | `fldEAl8K8Sn0gvC98` | Compositions | Primary composition(s) for this recording |
+| Compositions 2 | `fld3gjnOrMPcFZalU` | Compositions | Overflow slot |
+| Compositions 3 | `fldn4r74Eub5FushA` | Compositions | Overflow slot |
+| Primary Artist | `fld9vMhhhV6aAZPZP` | Artists | Primary credited act |
+| Featured Artist | `fldr6WmY3lmlfnTrb` | Artists | Featured credited act |
+| Master Owner 1 | `fldMKw9veaxGqmWJy` | Master Owners | Primary master rights holder |
+| Master Owner 2 | `fldtEeYpvscGJUiCf` | Master Owners | Second ownership slot |
+| Master Owner 3 | `fldEw8iScPnOFWTx0` | Master Owners | Third ownership slot |
+| REGISTRATION PROJECT (SOUNDEXCHANGE) 3 | `fldvX8g1YQ40aEtW4` | REGISTRATION PROJECT (SOUNDEXCHANGE) | SoundExchange registration record for this recording |
+| REGISTRATION PROJECT (PRO +MLC) | `fldEUVTZBGYl5tb0v` | REGISTRATION PROJECT (PRO +MLC) | PRO/MLC registration — reverse side of Reg.PRO.Matched Recording on MLC |
+| APM Dist Mgmt | `flddt6bS2GN56LUQY` | APM Dist Mgmt | APM distribution records |
+| Chevy Showroom Dist Mgmt | `flddAZaL7CL5QwgH1` | Chevy Showroom Dist Mgmt | Chevy Showroom distribution records |
+| Legal Docs | `fldVZMnGqosAZKLjf` | Legal Docs | Agreements covering this recording |
+
+---
+
+### Compositions (`tblomWINKPjfgAVpo`)
+
+#### Aggregate / roll-up links (safe to read; written via individual slots below)
+
+| Field | field_id | → Table | Notes |
+|-------|----------|---------|-------|
+| Recordings | `fldVjjMa9H9Zpx9p0` | Recordings | "Recordings of the composition" |
+| Recordings 2 | `fldxWNmJpXpvsObEg` | Recordings | Overflow slot |
+| Recordings 3 | `fldYObdWITjl5fAAO` | Recordings | Overflow slot |
+| Releases | `fldJj9yZLZEdu8qS8` | Releases | "Releases with a recording of the composition" |
+| Releases 2 | `fldQlJmvFWq4ipS17` | Releases | Overflow slot |
+| Releases 3 | `fldF908RO6LCB39D5` | Releases | Overflow slot |
+| All Songwriters | `fldRfWFbfjTZXzfKP` | Songwriters | Union of all Songwriter 1–9 slots |
+| All Original Publishers | `fldkIOo7kToJaT5zm` | Publishers | Union of all Original Pub slots |
+| All Admin Publishers | `fld58IACBmYnW9DJu` | Publishers | Union of all Admin Pub slots |
+| All Sub-Publishers | `fldMf59kc6MdOns1n` | Publishers | Union of all Sub-Pub slots |
+| REGISTRATION PROJECT | `fldN5elY1M8qIXXZ4` | REGISTRATION PROJECT (PRO +MLC) | Reverse side of Reg.PRO.Compositions |
+| Legal Docs | `fldh0MvKdlr37yU6N` | Legal Docs | Agreements covering this composition |
+
+#### Per-songwriter ownership slots
+
+Each co-writer gets a numbered slot (1–9). Each slot can have up to 4 publisher positions (Original Pub 1–4, Admin Pub 1–4, Sub-Pub 1). This is AirTable's way of encoding a per-songwriter ownership split.
+
+| Slot | Songwriter field_id | Orig Pub 1 | Admin Pub 1 | Sub-Pub 1 |
+|------|---------------------|------------|-------------|-----------|
+| SW 1 | `fldLhXZcoaevUSLlA` | `fldcx8y9D1KbIfCCj` | `fldeNG9WWWEeKzHpN` | `fldMi4ctlHPOaPFMD` |
+| SW 2 | `fldeivT63AcOXMinA` | `fld4085JeJSnRKbhA` | `fld2pifFJ2sg6UMRo` | `fld9zTSYx2pv31dxT` |
+| SW 3 | `fldpQwAEw0mATtMW4` | `fldVAiZ0RFyEih9HO` | `fldiKRkycbb71x06O` | `fld8ssi2tFWvUy7WO` |
+| SW 4 | `fldfi9zF7k7eyzN3E` | `fldqbaFomnWoWwRwi` | `fldqXGTiRaLiF4ZKx` | — |
+| SW 5 | `fld94WOrOzwY3ZZr4` | `fldwZSHeismDTtoRm` | `fldTBUGYFJFk2GA0k` | — |
+| SW 6 | `fldspvCZJR5LI2KMM` | `fldGo6i2jCDh3VWYM` | `fldupwtvdkBPnmeUv` | — |
+| SW 7 | `fldd3R26JG9uqgw9P` | `fldVFyqtVZKZFDxUc` | `fldsCeVEfrGptKpJc` | — |
+| SW 8 | `fldCtxeKcFoop5kpv` | `fldg4VsKIA2ABmEY7` | `fld4Q0oVqasrLgOPZ` | — |
+| SW 9 | `fld3prOTF7TdS4cdj` | `fldPr6m9Tnf83vlJ0` | `fldM8ji8hdvlOs2qX` | — |
+
+Each songwriter slot also has Orig Pub 2–4 and Admin Pub 2–4 fields for cases where a writer has multiple publishers in the chain (original + admin + sub). For the full field_id list see the Metadata API output.
+
+---
+
+### Songwriters (`tbl2KLh2RIrS5AmSX`)
+
+| Field | field_id | → Table | Notes |
+|-------|----------|---------|-------|
+| Compositions | `fldEoEyYlIjaKwrkq` | Compositions | Reverse side of Compositions.All Songwriters |
+| Compositions 2–8 | `fld0bWrdHt8Z8ONQz`–`fld06Logrgm1PYtJO` | Compositions | Auto-generated reverses of Songwriter 1–8 slots on Compositions |
+| Compositions 7 copy | `fldKl1LiSp8T5mJIT` | Compositions | Reverse of Composer.Songwriter 8 slot (legacy name) |
+| Compositions 7 copy copy | `fldSdlzArrF30VgBR` | Compositions | Reverse of Composer.Songwriter 9 slot (legacy name) |
+| Published by | `fld5mmxZv286NzYCs` | Publishers | "Publishers that have published work by the Songwriter" |
+| Legal Docs | `fldwccASH977BT3le` | Legal Docs | Agreements involving this songwriter |
+
+---
+
+### Publishers (`tbl6TNKQRPfY3hXZ2`)
+
+#### Meaningful links
+
+| Field | field_id | → Table | Notes |
+|-------|----------|---------|-------|
+| Original Pub. Compositions | `fldun7E4qgE0odL9Q` | Compositions | Reverse of Compositions.All Original Publishers |
+| Admin Pub. Compositions | `fldpqaDDnpqZhO1Wf` | Compositions | Reverse of Compositions.All Admin Publishers |
+| Compositions | `fldlrC144iV4zNWG2` | Compositions | Reverse of Compositions.All Sub-Publishers |
+| Songwriters | `fldP7iqjXfkQMvTdS` | Songwriters | Reverse of Songwriters.Published by |
+| In Care Of | `fldPx8Rrlljp0Uw94` | Publishers (self) | "This Publisher is being administered and/or sub-published by ________" |
+| Administered Pubs | `fldMTRizR1S5wOPbx` | Publishers (self) | "This Publisher acts as an Admin Publisher for _____________" |
+| Legal Docs | `fldFFEnrBSdCtHfvZ` | Legal Docs | Agreements involving this publisher |
+
+#### Overflow / [DON'T DELETE] Compositions fields (all → Compositions)
+
+These are auto-generated reverse sides of the per-songwriter publisher slots on the Compositions table. There are approximately 35 of them with names like `Compositions 2`, `Compositions 2 copy copy copy...`, `[DON'T DELETE] Songwriter 1 Admin Pub. 1`, etc. None should be written to directly — they are read-only roll-ups on the Publishers side. The meaningful write path is always via the Compositions table's `Songwriter N Original/Admin Pub M` fields.
+
+---
+
+### Artists (`tbla7zxpHm76x0Aj9`)
+
+| Field | field_id | → Table | Notes |
+|-------|----------|---------|-------|
+| Primary Recordings | `fld9Eyowsg94qVrJe` | Recordings | Recordings where this act is the primary artist |
+| Featured Recordings | `flddCYswYDG3kkOY8` | Recordings | Recordings where this act is a featured artist |
+| Primary Releases | `fldMZrQCVME3cIBnE` | Releases | "Releases where the Artist is the Primary Artist" |
+| Featured Releases | `fldXrX9pcvBTDf7YF` | Releases | "Releases that Artist is featured on" |
+| Legal Docs | `fldnpu57KRbN8DIAg` | Legal Docs | Agreements involving this artist |
+
+---
+
+### Master Owners (`tblqfRCyEWjlfTMBd`)
+
+| Field | field_id | → Table | Notes |
+|-------|----------|---------|-------|
+| Related labels | `fldocX256KHFPNvak` | Master Owners (self) | "If you're viewing a Parent Type master owner, then these are their Subdivision labels. If you're viewing a Subdivision Type, this is their Parent label" |
+| Owned Recordings | `fldxyKSwINUjwCSfK` | Recordings | Recordings where this entity is Master Owner 1 |
+| Original releases | `fldBpxKhX21ESiiuE` | Releases | "Were responsible for the original release of these Releases"; inverse of Releases.Current release label (see §6) |
+| Releases | `fldWAKqc4GPb7uesN` | Releases | Inverse of Releases.Original release label (see §6) |
+| [DON'T DELETE] Master Owner 2 in Recordings | `fld3eWa7SYrEN2HkL` | Recordings | Auto-generated reverse of Recordings.Master Owner 2 — do not write |
+| [DON'T DELETE] Master Owner 3 in Recordings | `fld1Iq5MydRBkOktY` | Recordings | Auto-generated reverse of Recordings.Master Owner 3 — do not write |
+| Legal Docs | `fldZxv4TMJuPZNWPH` | Legal Docs | Agreements involving this master owner |
+
+---
+
+### Legal Docs (`tbl0JjCNEaGmFGAkx`)
+
+A cross-cutting table — a single legal document record can link to any combination of entities across both rights sides.
+
+| Field | field_id | → Table | Notes |
+|-------|----------|---------|-------|
+| Master Owner | `fldXUjQvuEbtzF2y6` | Master Owners | "Master Owners involved in this legal document." |
+| Artists | `fld589CVNN3Dz4LIo` | Artists | "Artists involved in this legal document." |
+| Linked Compositions | `fldD2pmUU5QiXFHSx` | Compositions | "Compositions involved in this legal document." |
+| Publisher(s) | `fldE9rUE0HpFuoxGX` | Publishers | "Publishers involved in this legal document." |
+| Songwriter(s) | `fld1qPXmNU8VlgWOj` | Songwriters | "Songwriters involved in this legal document." |
+| Recordings | `fldPBENvLLuCsdN7g` | Recordings | "Recordings involved in this legal document." |
+| Releases | `fldoyrjPJv0VJzsns` | Releases | "Releases involved in this legal document." |
+| Related Legal Docs | `fldTIZRdifmWsei2p` | Legal Docs (self) | Self-referential link for related/parent agreements |
+| From field: Related Legal Docs | `flddf50UzWyJzJA7G` | Legal Docs (self) | Auto-generated reverse side of Related Legal Docs — do not write |
+
+---
+
+### REGISTRATION PROJECT (PRO +MLC) (`tbl7FGL9AZlKaqOwm`)
+
+Tracks composition-side registrations with Performing Rights Organizations and the Mechanical Licensing Collective.
+
+| Field | field_id | → Table | Notes |
+|-------|----------|---------|-------|
+| Compositions | `fldHiMGgWMpTNCQmV` | Compositions | The composition being registered |
+| Matched Recording on MLC | `fldTTsqgKn6xtbFKy` | Recordings | "Matched Recording on MLC" — the specific recording the MLC matched during registration |
+
+---
+
+### REGISTRATION PROJECT (SOUNDEXCHANGE) (`tbliX5cAVK47tYsL8`)
+
+Tracks recording-side registrations with SoundExchange (digital performance royalties).
+
+| Field | field_id | → Table | Notes |
+|-------|----------|---------|-------|
+| Recordings | `fld2j5Wejenu7sbM4` | Recordings | The recording being registered with SoundExchange |
+
+---
+
+### APM Dist Mgmt (`tbllGX2Hxg3SGhJMa`)
+
+Distribution management records for the APM channel.
+
+| Field | field_id | → Table | Notes |
+|-------|----------|---------|-------|
+| From Release | `fldJNJzhWluDYWDTS` | Releases | "This is the release(s) that the recording is from. NOTE: This release may/may not be the same as the CD ID that recording is packaged in by APM. We're using release to help us verify metadata like 'Primary Artist' etc." |
+| Recording | `fldHwS1bgXbIMxljd` | Recordings | The specific recording in this distribution record |
+
+---
+
+### Chevy Showroom Dist Mgmt (`tblRqFtQrPCNB1fwT`)
+
+Distribution management records for the Chevy Showroom channel.
+
+| Field | field_id | → Table | Notes |
+|-------|----------|---------|-------|
+| Release | `fld8ZRGggXaSZ6WPr` | Releases | The release being distributed |
+| Recordings | `fldu3zfcd8SW7QJwG` | Recordings | The recording in this distribution record |
+
+---
+
+### PROGRESS REPORT (`tblPBXgEXtDH6TaRR`)
+
+Progress tracking entries on the recording side.
+
+| Field | field_id | → Table | Notes |
+|-------|----------|---------|-------|
+| Releases | `fldYG5yQVaoJrH8LE` | Releases | Releases tracked in this report |
+
+---
+
+## 4. Tables Not Covered Here
+
+These tables exist in the base but are excluded from this reference:
+
+| Table | Reason |
+|-------|--------|
+| Dot Records Data | External data import; not part of the active catalog workflow |
+| Resources | Internal reference/links table; no catalog entity links |
+| SCRATCH | Working scratch space; not canonical data |
+| artists_copy | Duplicate of Artists; excluded from `load_tables()` in md_parser.py |
+
+---
+
+## 5. Self-Referential Tables
+
+Three tables link to themselves:
+
+**Publishers → Publishers**
+- `In Care Of` (`fldPx8Rrlljp0Uw94`): "This Publisher is being administered and/or sub-published by ________" — points to the parent/admin publisher above this one in the publishing chain.
+- `Administered Pubs` (`fldMTRizR1S5wOPbx`): "This Publisher acts as an Admin Publisher for _____________" — points to the child publishers this publisher administers.
+
+These two are separate, independent fields (neither is the auto-generated reverse of the other — confirmed by both having empty `inverseLinkFieldId`). They model a directed graph of publisher relationships.
+
+**Master Owners → Master Owners**
+- `Related labels` (`fldocX256KHFPNvak`): "If you're viewing a Parent Type master owner, then these are their Subdivision labels. If you're viewing a Subdivision Type, this is their Parent label" — models parent/imprint relationships between entities. Also an independent self-referential field (no auto-generated reverse).
+
+**Legal Docs → Legal Docs**
+- `Related Legal Docs` (`fldTIZRdifmWsei2p`) / `From field: Related Legal Docs` (`flddf50UzWyJzJA7G`): Bidirectional link between related agreements. Unlike the Publisher/Master Owner self-refs, this one does have an auto-generated reverse side (`flddf50UzWyJzJA7G`) — do not write to the reverse.
+
+---
+
+## 6. Key Design Notes
+
+### Release → Compositions denormalization
+
+The canonical data path is `Release → Recordings → Compositions`. However, the Releases table also has direct `Compositions`, `Compositions 2`, and `Compositions 3` fields. These appear to be a convenience denormalization to enable quick lookups without traversing through Recordings. When writing new data, always populate via `Recordings → Compositions`; the Releases.Compositions fields should stay in sync automatically through AirTable's bidirectional links.
+
+### Releases label field naming quirk
+
+The field naming on Releases vs. Master Owners is counterintuitive:
+
+| Releases field | → Master Owners field | API description |
+|---|---|---|
+| `Original release label` | → `Releases` (no description) | The master owner who is tracked generically |
+| `Current release label` | → `Original releases` | "Were responsible for the original release" |
+
+The `Master Owners.Original releases` description ("Were responsible for the original release of these Releases") is the inverse of `Releases.Current release label`, not `Original release label`. This naming inversion appears to be a historical artifact — trust the field_id pairs above, not the field names, when writing code.
+
+### Per-songwriter publisher slots on Compositions
+
+AirTable has no native join table. The Compositions table replicates a proper ownership-split join table by having explicit per-songwriter × per-publisher fields (up to Songwriter 9 × Pub 4). Each slot independently captures one publisher's role for one co-writer. The aggregate fields (`All Original Publishers`, `All Admin Publishers`, `All Sub-Publishers`, `All Songwriters`) are roll-ups of these individual slots.
+
+### Publisher overflow fields
+
+The Publishers table accumulates ~35 link fields back to Compositions, most with names like `Compositions 2 copy copy copy...`. These are the auto-generated reverse sides of all the per-songwriter publisher slot fields on the Compositions table. They all point to the same Compositions table and are read-only from the Publishers side. None should be written to directly.
+
+### [DON'T DELETE] fields
+
+Any field prefixed `[DON'T DELETE]` is an auto-generated reverse-side link. AirTable requires them to exist to maintain bidirectional link integrity. They should never be written to — always write to the primary side of the link.

--- a/DOCS/parse_airtable_docs.py
+++ b/DOCS/parse_airtable_docs.py
@@ -1,0 +1,357 @@
+"""
+parse_airtable_docs.py
+
+Parses the AirTable HTML API reference and produces one markdown file
+per table inside ./output/.
+
+Usage:
+    uv run python parse_airtable_docs.py "Airtable API - The Gold Label Artists Database.html"
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote
+
+from bs4 import BeautifulSoup, Tag
+
+BASE_ID = "appEurfA8kXQE3slK"
+
+OPERATION_LABELS = {
+    "list": "List Records",
+    "retrieve": "Retrieve a Record",
+    "create": "Create Records",
+    "update": "Update / Upsert Records",
+    "delete": "Delete Records",
+}
+
+OPERATION_METHODS = {
+    "list": "GET",
+    "retrieve": "GET",
+    "create": "POST",
+    "update": "PATCH",
+    "delete": "DELETE",
+}
+
+
+# ---------------------------------------------------------------------------
+# 1. Load
+# ---------------------------------------------------------------------------
+
+def load_soup(filepath: str) -> BeautifulSoup:
+    print(f"Loading {filepath} …", file=sys.stderr)
+    with open(filepath, encoding="utf-8") as fh:
+        return BeautifulSoup(fh, "lxml")
+
+
+# ---------------------------------------------------------------------------
+# 2. Extract tables
+# ---------------------------------------------------------------------------
+
+def extract_tables(soup: BeautifulSoup) -> list[dict]:
+    """Return a list of table dicts extracted from the soup."""
+    tables = []
+
+    # Each table lives inside a div[ng-repeat="table in application.tables"]
+    table_divs = soup.find_all(
+        "div", attrs={"ng-repeat": "table in application.tables"}
+    )
+
+    for div in table_divs:
+        h1 = div.find("h1", attrs={"section-name": re.compile(r"^table:[^:]+$")})
+        if h1 is None:
+            continue
+
+        section_name = h1.get("section-name", "")  # e.g. "table:compositions"
+        table_key = unquote(section_name.removeprefix("table:")).strip()  # "compositions"
+        display_name = h1.get_text(strip=True).removesuffix(" Table").strip()
+
+        # Table ID — in the first docSection.fields > span.tableId
+        table_id_tag = div.find("span", class_="tableId")
+        table_id = table_id_tag.get_text(strip=True) if table_id_tag else ""
+
+        # Fields
+        fields = extract_fields(div, table_key)
+
+        # Operations
+        operations = {}
+        for op in OPERATION_LABELS:
+            op_data = extract_operation(div, table_key, op)
+            if op_data:
+                operations[op] = op_data
+
+        tables.append(
+            {
+                "key": table_key,
+                "display_name": display_name,
+                "table_id": table_id,
+                "fields": fields,
+                "operations": operations,
+            }
+        )
+        print(f"  parsed: {display_name} ({len(fields)} fields)", file=sys.stderr)
+
+    return tables
+
+
+# ---------------------------------------------------------------------------
+# 3. Extract fields
+# ---------------------------------------------------------------------------
+
+def extract_fields(table_div: Tag, table_key: str) -> list[dict]:
+    """Find all field rows for this table."""
+    fields = []
+
+    # Field rows live in div.docSection.fields.ng-scope (one div per field)
+    # Each contains a div.fieldsRow (not the header one)
+    for section in table_div.find_all("div", class_=lambda c: c and "fields" in c and "ng-scope" in c):
+        row = section.find("div", class_="fieldsRow")
+        if row is None:
+            continue
+
+        name_tag = row.find("span", class_="columnName")
+        id_tag = row.find("span", class_="columnId")
+        type_tag = row.find("div", class_="type")
+        desc_tag = row.find("div", class_="description")
+
+        name = name_tag.get_text(strip=True) if name_tag else ""
+        field_id = id_tag.get_text(strip=True) if id_tag else ""
+        field_type = type_tag.get_text(strip=True) if type_tag else ""
+        # Strip valueType sub-div from description
+        description = ""
+        if desc_tag:
+            # Remove the valueType span/div so we only get the prose
+            for vt in desc_tag.find_all(class_="valueType"):
+                vt.decompose()
+            description = " ".join(desc_tag.get_text(" ", strip=True).split())
+
+        if name:
+            fields.append(
+                {
+                    "name": name,
+                    "id": field_id,
+                    "type": field_type,
+                    "description": description,
+                }
+            )
+
+    return fields
+
+
+# ---------------------------------------------------------------------------
+# 4. Extract a single operation
+# ---------------------------------------------------------------------------
+
+def _extract_curl(section_div: Tag) -> list[str]:
+    """Return all curl command strings found in code blocks within section_div."""
+    curl_blocks = []
+    for pre in section_div.find_all("pre"):
+        code = pre.find("code")
+        if code:
+            text = code.get_text()
+            stripped = text.strip()
+            if stripped.startswith("curl"):
+                curl_blocks.append(stripped)
+    return curl_blocks
+
+
+def _extract_description(section_div: Tag) -> str:
+    """Return the first meaningful paragraph of descriptive text."""
+    text_div = section_div.find("div", class_="text")
+    if text_div is None:
+        return ""
+    paragraphs = []
+    for p in text_div.find_all("p", recursive=True):
+        t = " ".join(p.get_text(" ", strip=True).split())
+        if t and len(t) > 20:
+            paragraphs.append(t)
+            if len(paragraphs) == 2:
+                break
+    return "\n\n".join(paragraphs)
+
+
+def _extract_parameters(section_div: Tag) -> list[dict]:
+    """Return a list of {name, type, required, description} from pagination divs."""
+    params = []
+    for name_div in section_div.find_all("div", class_="paginationName"):
+        raw = name_div.get_text(" ", strip=True)
+        # First word(s) before a code.type tag is the param name
+        code_type = name_div.find("code", class_="type")
+        param_type = code_type.get_text(strip=True) if code_type else ""
+        required_tag = name_div.find("span", class_="required")
+        optional_tag = name_div.find("span", class_="optional")
+        required = "required" if required_tag else "optional"
+
+        # Derive name by removing the type and required/optional text
+        name = raw
+        if code_type:
+            name = name.replace(code_type.get_text(strip=True), "").strip()
+        if required_tag:
+            name = name.replace("required", "").strip()
+        if optional_tag:
+            name = name.replace("optional", "").strip()
+
+        # Description is in the next sibling div.paginationDescription
+        desc = ""
+        next_sib = name_div.find_next_sibling("div", class_="paginationDescription")
+        if next_sib:
+            desc = " ".join(next_sib.get_text(" ", strip=True).split())[:300]
+
+        params.append(
+            {
+                "name": name,
+                "type": param_type,
+                "required": required,
+                "description": desc,
+            }
+        )
+    return params
+
+
+def extract_operation(table_div: Tag, table_key: str, op: str) -> dict | None:
+    """Return operation dict for op in ['list','retrieve','create','update','delete']."""
+    url_key = table_key.replace(" ", "%20")
+    # Match either encoded or plain section-name (BS4 gets raw attr value)
+    h2 = table_div.find(
+        "h2",
+        attrs={"section-name": lambda v: v and unquote(v) == f"table:{table_key}:{op}"},
+    )
+    if h2 is None:
+        return None
+
+    # h2 is inside a div.docSection — that's our section container
+    section_div = h2.parent
+    if section_div is None:
+        return None
+
+    description = _extract_description(section_div)
+    curl_commands = _extract_curl(section_div)
+    parameters = _extract_parameters(section_div) if op == "list" else []
+
+    return {
+        "op": op,
+        "description": description,
+        "curl_commands": curl_commands,
+        "parameters": parameters,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 5. Render markdown
+# ---------------------------------------------------------------------------
+
+def _safe_filename(name: str) -> str:
+    """Convert a table display name to a safe, lowercase filename."""
+    s = name.lower()
+    # Remove special chars, keep alphanumeric and spaces
+    s = re.sub(r"[^\w\s-]", " ", s)
+    # Collapse whitespace to hyphens
+    s = re.sub(r"[\s_]+", "-", s.strip())
+    # Remove leading/trailing hyphens
+    s = s.strip("-")
+    return s + ".md"
+
+
+def _escape_md(text: str) -> str:
+    """Escape pipe characters inside markdown table cells."""
+    return text.replace("|", "\\|")
+
+
+def render_markdown(table: dict) -> str:
+    lines: list[str] = []
+
+    lines.append(f"# {table['display_name']}\n")
+    lines.append(f"**Table ID:** `{table['table_id']}`  ")
+    lines.append(f"**Base ID:** `{BASE_ID}`\n")
+    lines.append("---\n")
+
+    # --- Fields ---
+    lines.append("## Fields\n")
+    if table["fields"]:
+        lines.append("| Field Name | Field ID | Type | Description |")
+        lines.append("|------------|----------|------|-------------|")
+        for f in table["fields"]:
+            name = _escape_md(f["name"])
+            fid = _escape_md(f["id"])
+            ftype = _escape_md(f["type"])
+            desc = _escape_md(f["description"])
+            lines.append(f"| {name} | `{fid}` | {ftype} | {desc} |")
+    else:
+        lines.append("_No fields found._")
+    lines.append("")
+
+    # --- Operations ---
+    for op, label in OPERATION_LABELS.items():
+        if op not in table["operations"]:
+            continue
+
+        op_data = table["operations"][op]
+        method = OPERATION_METHODS[op]
+        table_url_name = table["key"].replace(" ", "%20")
+
+        lines.append("---\n")
+        lines.append(f"## {label}\n")
+        lines.append(
+            f"**Endpoint:** `{method} /v0/{BASE_ID}/{table_url_name}`\n"
+        )
+
+        if op_data["description"]:
+            lines.append(op_data["description"])
+            lines.append("")
+
+        # Curl examples
+        for curl in op_data["curl_commands"]:
+            lines.append("```bash")
+            lines.append(curl)
+            lines.append("```\n")
+
+        # Parameters (list only)
+        if op_data["parameters"]:
+            lines.append("### Query Parameters\n")
+            lines.append("| Parameter | Type | Required | Description |")
+            lines.append("|-----------|------|----------|-------------|")
+            for p in op_data["parameters"]:
+                pname = _escape_md(p["name"])
+                ptype = _escape_md(p["type"])
+                req = p["required"]
+                desc = _escape_md(p["description"])
+                lines.append(f"| `{pname}` | {ptype} | {req} | {desc} |")
+            lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# 6. Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Parse AirTable HTML docs → per-table markdown files"
+    )
+    parser.add_argument("html_file", help="Path to the AirTable HTML doc")
+    parser.add_argument(
+        "-o", "--output-dir", default="output", help="Output directory (default: ./output)"
+    )
+    args = parser.parse_args()
+
+    soup = load_soup(args.html_file)
+    tables = extract_tables(soup)
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"\nWriting {len(tables)} markdown files to {output_dir}/", file=sys.stderr)
+    for table in tables:
+        filename = _safe_filename(table["display_name"])
+        md = render_markdown(table)
+        out_path = output_dir / filename
+        out_path.write_text(md, encoding="utf-8")
+        print(f"  → {out_path}", file=sys.stderr)
+
+    print("\nDone.", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,47 @@
+[project]
+name = "airtable-pbgl"
+version = "0.1.0"
+description = "AirTable PBGL internal CLI and Textual TUI"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "beautifulsoup4>=4.14.3",
+    "lxml>=6.0.2",
+    "python-dotenv>=1.0",
+    "requests>=2.32",
+    "textual>=0.80",
+    "typer>=0.15",
+]
+
+[project.scripts]
+atp = "atp.main:app"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/atp"]
+
+[dependency-groups]
+dev = [
+    "mypy",
+    "pytest>=8",
+    "pytest-cov",
+    "ruff",
+]
+
+[tool.pytest.ini_options]
+addopts = ["--import-mode=importlib"]
+pythonpath = ["src"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = false

--- a/scripts/import_chevy_songs.py
+++ b/scripts/import_chevy_songs.py
@@ -1,0 +1,252 @@
+"""Import Pat Boone Chevy Showroom songs from song_index.csv into AirTable.
+
+Usage:
+    uv run python scripts/import_chevy_songs.py [--dry-run]
+    uv run python scripts/import_chevy_songs.py --episodes 60
+    uv run python scripts/import_chevy_songs.py --episodes 60,61,62
+"""
+from __future__ import annotations
+
+import csv
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import typer
+from dotenv import load_dotenv
+
+# Package is installed via uv; import directly.
+from airtable_tui.api import AirtableClient
+
+CHEVY_TABLE_ID = "tblRqFtQrPCNB1fwT"
+BASE_ID = "appEurfA8kXQE3slK"
+MIN_EPISODE = 60  # default lower bound when --episodes is not specified
+
+CSV_PATH = Path(
+    "/Users/daniellyons/Library/CloudStorage/Box-Box"
+    "/The Gold Label/The Pat Boone Chevy Showroom"
+    "/Episode Info/song_index.csv"
+)
+
+# CSV column positions (header has a duplicate "guest_artists" column — use positional access)
+COL_EPISODE = 0
+COL_TRACK = 1
+COL_TITLE = 2
+COL_DATE = 3
+COL_GUEST = 4
+
+app = typer.Typer(add_completion=False)
+
+
+# ---------------------------------------------------------------------------
+# Date helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_iso_date(s: str) -> str:
+    """'October 3, 1957' → '1957-10-03'."""
+    return datetime.strptime(s.strip(), "%B %d, %Y").strftime("%Y-%m-%d")
+
+
+def format_long_date(s: str) -> str:
+    """'October 3, 1957' → 'October 3, 1957' (no leading zero on day)."""
+    dt = datetime.strptime(s.strip(), "%B %d, %Y")
+    return f"{dt.strftime('%B')} {dt.day}, {dt.year}"
+
+
+# ---------------------------------------------------------------------------
+# AirTable helpers
+# ---------------------------------------------------------------------------
+
+
+def list_all_records(client: AirtableClient, table_id: str) -> list[dict[str, object]]:
+    """Fetch every record from *table_id*, following AirTable's offset pagination."""
+    all_records: list[dict[str, object]] = []
+    offset = ""
+    while True:
+        result = client.list_records(table_id, offset=offset)
+        records = result.get("records")
+        if isinstance(records, list):
+            all_records.extend(records)  # type: ignore[arg-type]
+        next_offset = result.get("offset")
+        if not next_offset:
+            break
+        offset = str(next_offset)
+    return all_records
+
+
+def get_existing_keys(client: AirtableClient, table_id: str) -> set[tuple[str, str]]:
+    """Return {(episode_str, title_str)} for all records already in *table_id*."""
+    records = list_all_records(client, table_id)
+    keys: set[tuple[str, str]] = set()
+    for rec in records:
+        fields = rec.get("fields")
+        if not isinstance(fields, dict):
+            continue
+        ep = str(fields.get("Episode #", "")).strip()
+        title = str(fields.get("Recording Title", "")).strip()
+        if ep and title:
+            keys.add((ep, title))
+    return keys
+
+
+# ---------------------------------------------------------------------------
+# CSV → AirTable field mapping
+# ---------------------------------------------------------------------------
+
+
+def build_fields(row: list[str]) -> dict[str, object]:
+    """Build the AirTable fields dict from a CSV row (positional columns)."""
+    episode_num = row[COL_EPISODE].strip()
+    track_num = row[COL_TRACK].strip()
+    song_title = row[COL_TITLE].strip()
+    raw_date = row[COL_DATE].strip()
+    guest = row[COL_GUEST].strip() if len(row) > COL_GUEST else ""
+
+    long_date = format_long_date(raw_date)
+    album_title = f"{song_title} (Live On The Pat Boone Chevy Showroom, {long_date})"
+
+    title_version = f"Live On The Pat Boone Chevy Showroom, {long_date}"
+
+    fields: dict[str, object] = {
+        "Recording Title": song_title,
+        "Episode #": episode_num,
+        "Date First Aired": parse_iso_date(raw_date),
+        "Album Release Title": album_title,
+        "Title Version": title_version,
+        "Notes": f"Track #{track_num}",
+    }
+    if guest:
+        fields["Featured Artist"] = [a.strip() for a in guest.split(",") if a.strip()]
+    return fields
+
+
+# ---------------------------------------------------------------------------
+# Main command
+# ---------------------------------------------------------------------------
+
+
+def parse_episodes(value: str | None) -> set[int] | None:
+    """Parse a comma-separated list of episode numbers into a set, or None if not provided."""
+    if value is None:
+        return None
+    parts = [p.strip() for p in value.split(",") if p.strip()]
+    result: set[int] = set()
+    for part in parts:
+        try:
+            result.add(int(part))
+        except ValueError:
+            typer.secho(f"Invalid episode number: {part!r}", fg=typer.colors.RED, err=True)
+            raise typer.Exit(1)
+    return result
+
+
+@app.command()
+def main(
+    csv_path: Path = typer.Option(CSV_PATH, "--csv", help="Path to song_index.csv"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Print records without writing to AirTable"),
+    episodes: str | None = typer.Option(None, "--episodes", help="Comma-separated episode numbers to import (e.g. '60' or '60,61,62'). Defaults to all episodes ≥60."),
+) -> None:
+    """Import Chevy Showroom songs from CSV into AirTable, skipping duplicates."""
+
+    # Load API token
+    project_root = Path(__file__).parent.parent
+    load_dotenv(project_root / ".env")
+    token = os.environ.get("AIRTABLE_API_TOKEN")
+    if not token:
+        typer.secho("AIRTABLE_API_TOKEN is not set — check your .env file.", fg=typer.colors.RED, err=True)
+        raise typer.Exit(1)
+
+    client = AirtableClient(token=token, base_id=BASE_ID)
+
+    # Parse episode filter
+    episode_filter = parse_episodes(episodes)
+    if episode_filter is not None:
+        typer.echo(f"Filtering to episodes: {sorted(episode_filter)}", err=True)
+    else:
+        typer.echo(f"Importing all episodes ≥{MIN_EPISODE}.", err=True)
+
+    # Fetch existing records for duplicate detection
+    typer.echo("Fetching existing records from AirTable…", err=True)
+    existing_keys = get_existing_keys(client, CHEVY_TABLE_ID)
+    typer.echo(f"  {len(existing_keys)} existing records found.", err=True)
+
+    # Parse CSV and build import list
+    rows_to_import: list[dict[str, object]] = []
+    skipped_episode = 0
+    skipped_blank = 0
+    skipped_duplicate = 0
+
+    with csv_path.open(newline="", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        next(reader)  # skip header row
+        for row in reader:
+            if len(row) < 4:
+                continue
+
+            episode_str = row[COL_EPISODE].strip()
+            song_title = row[COL_TITLE].strip()
+
+            # Skip missing/non-numeric episode numbers
+            if not episode_str:
+                skipped_blank += 1
+                continue
+            try:
+                episode_num = int(episode_str)
+            except ValueError:
+                skipped_blank += 1
+                continue
+
+            # Filter by selected episodes or default lower bound
+            if episode_filter is not None:
+                if episode_num not in episode_filter:
+                    skipped_episode += 1
+                    continue
+            elif episode_num < MIN_EPISODE:
+                skipped_episode += 1
+                continue
+
+            # Skip rows with no song title
+            if not song_title:
+                skipped_blank += 1
+                continue
+
+            # Skip duplicates already in AirTable
+            if (episode_str, song_title) in existing_keys:
+                skipped_duplicate += 1
+                continue
+
+            rows_to_import.append(build_fields(row))
+
+    typer.echo(
+        f"  Skipped {skipped_episode} rows (episodes ≤59), "
+        f"{skipped_blank} blank, {skipped_duplicate} duplicates.",
+        err=True,
+    )
+    typer.echo(f"  {len(rows_to_import)} records to import.", err=True)
+
+    if not rows_to_import:
+        typer.echo("Nothing to import.", err=True)
+        return
+
+    if dry_run:
+        json.dump(rows_to_import, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    # Batch-create in groups of 10 (AirTable limit per request)
+    created = 0
+    for i in range(0, len(rows_to_import), 10):
+        batch = rows_to_import[i : i + 10]
+        result = client.create_records(CHEVY_TABLE_ID, batch, typecast=True)
+        n = len(result.get("records", []))  # type: ignore[arg-type]
+        created += n
+        typer.echo(f"  Created {created}/{len(rows_to_import)}…", err=True)
+
+    typer.echo(f"Done. {created} records created.", err=True)
+
+
+if __name__ == "__main__":
+    app()

--- a/scripts/link_chevy_releases.py
+++ b/scripts/link_chevy_releases.py
@@ -1,0 +1,330 @@
+"""Create Releases and Recordings for unlinked Chevy Showroom Dist Mgmt rows.
+
+Each unlinked Chevy row gets one Release and one Recording wired up via four
+phases that mirror AirTable's bidirectional link requirements:
+
+  Phase 1 — Create Release (links Release → Chevy; Chevy.Release auto-populates)
+  Phase 2 — Create Recording (links Recording → Release via Original Release)
+  Phase 3 — Patch Release with Recordings link
+  Phase 4 — Patch Chevy row with Recordings link
+
+Idempotent: rows that already have a Release linked are skipped.
+
+Usage:
+    uv run python scripts/link_chevy_releases.py --dry-run
+    uv run python scripts/link_chevy_releases.py --episodes 60
+    uv run python scripts/link_chevy_releases.py --episodes 60,61,62
+    uv run python scripts/link_chevy_releases.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import typer
+from dotenv import load_dotenv
+
+from airtable_tui.api import AirtableClient
+
+CHEVY_TABLE_ID = "tblRqFtQrPCNB1fwT"
+RELEASES_TABLE_ID = "tbl7rjVKUd5faZ7fV"
+RECORDINGS_TABLE_ID = "tblESvQQmOBbEXAH0"
+BASE_ID = "appEurfA8kXQE3slK"
+BATCH_SIZE = 10
+
+app = typer.Typer(add_completion=False)
+
+
+# ---------------------------------------------------------------------------
+# AirTable helpers
+# ---------------------------------------------------------------------------
+
+
+def list_all_records(client: AirtableClient, table_id: str) -> list[dict[str, object]]:
+    """Fetch every record from *table_id*, following AirTable's offset pagination."""
+    all_records: list[dict[str, object]] = []
+    offset = ""
+    while True:
+        result = client.list_records(table_id, offset=offset)
+        records = result.get("records")
+        if isinstance(records, list):
+            all_records.extend(records)  # type: ignore[arg-type]
+        next_offset = result.get("offset")
+        if not next_offset:
+            break
+        offset = str(next_offset)
+    return all_records
+
+
+def fetch_unlinked_chevy_rows(
+    client: AirtableClient,
+    episode_filter: set[int] | None,
+) -> list[dict[str, object]]:
+    """Return Chevy rows that have no Release link yet."""
+    all_records = list_all_records(client, CHEVY_TABLE_ID)
+    unlinked = []
+    for rec in all_records:
+        fields = rec.get("fields")
+        if not isinstance(fields, dict):
+            continue
+        # Skip rows that already have a Release linked
+        if fields.get("Release"):
+            continue
+        # Apply optional episode filter
+        if episode_filter is not None:
+            ep_str = str(fields.get("Episode #", "")).strip()
+            try:
+                ep_num = int(ep_str)
+            except ValueError:
+                continue
+            if ep_num not in episode_filter:
+                continue
+        unlinked.append(rec)
+    return unlinked
+
+
+def build_pending(records: list[dict[str, object]]) -> list[dict[str, object]]:
+    """Map raw AirTable records to a flat list of pending rows.
+
+    Each entry contains the Chevy record ID, song title, album title, and
+    episode number. The release_id and recording_id slots start empty and are
+    filled in by the phase functions.
+
+    Rows missing Album Release Title or Recording Title are skipped.
+    """
+    pending = []
+    for rec in records:
+        fields = rec.get("fields")
+        if not isinstance(fields, dict):
+            continue
+        chevy_id = str(rec.get("id", "")).strip()
+        song_title = str(fields.get("Recording Title", "")).strip()
+        album_title = str(fields.get("Album Release Title", "")).strip()
+        episode = str(fields.get("Episode #", "")).strip()
+        if not chevy_id or not song_title or not album_title:
+            continue
+        pending.append({
+            "chevy_id": chevy_id,
+            "song_title": song_title,
+            "album_title": album_title,
+            "episode": episode,
+            "release_id": "",
+            "recording_id": "",
+        })
+    return pending
+
+
+# ---------------------------------------------------------------------------
+# Episode filter helper
+# ---------------------------------------------------------------------------
+
+
+def parse_episodes(value: str | None) -> set[int] | None:
+    """Parse a comma-separated list of episode numbers into a set, or None if not provided."""
+    if value is None:
+        return None
+    parts = [p.strip() for p in value.split(",") if p.strip()]
+    result: set[int] = set()
+    for part in parts:
+        try:
+            result.add(int(part))
+        except ValueError:
+            typer.secho(f"Invalid episode number: {part!r}", fg=typer.colors.RED, err=True)
+            raise typer.Exit(1)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Four-phase linking
+# ---------------------------------------------------------------------------
+
+
+def _check_response(result: dict[str, object], phase: str) -> None:
+    """Raise a clear error if AirTable returned an error payload."""
+    if "error" in result:
+        err = result["error"]
+        raise typer.Exit(
+            typer.secho(
+                f"  AirTable error in {phase}: {err}",
+                fg=typer.colors.RED,
+                err=True,
+            )
+            or 1
+        )
+    if "records" not in result:
+        raise typer.Exit(
+            typer.secho(
+                f"  Unexpected response in {phase} (no 'records' key): {result}",
+                fg=typer.colors.RED,
+                err=True,
+            )
+            or 1
+        )
+
+
+def phase1_create_releases(
+    client: AirtableClient,
+    pending: list[dict[str, object]],
+) -> None:
+    """Create one Release per pending row; mutates each row with its release_id.
+
+    Setting Releases.Chevy Showroom Dist Mgmt causes AirTable to auto-populate
+    the reverse ChesvyShowroom.Release field for free.
+    """
+    for i in range(0, len(pending), BATCH_SIZE):
+        batch = pending[i : i + BATCH_SIZE]
+        fields_list = [
+            {
+                "Release Title": row["album_title"],
+                "Chevy Showroom Dist Mgmt": [row["chevy_id"]],
+            }
+            for row in batch
+        ]
+        result = client.create_records(RELEASES_TABLE_ID, fields_list)
+        _check_response(result, "Phase 1 (create releases)")
+        created = result["records"]
+        for j, rec in enumerate(created):  # type: ignore[union-attr]
+            batch[j]["release_id"] = rec["id"]  # type: ignore[index]
+        typer.echo(
+            f"  Phase 1: created {len(created)}/{len(batch)} releases"
+            f" (total {i + len(created)}/{len(pending)})",
+            err=True,
+        )
+
+
+def phase2_create_recordings(
+    client: AirtableClient,
+    pending: list[dict[str, object]],
+) -> None:
+    """Create one Recording per pending row; mutates each row with its recording_id."""
+    for i in range(0, len(pending), BATCH_SIZE):
+        batch = pending[i : i + BATCH_SIZE]
+        fields_list = [
+            {
+                "Title of Recording": row["song_title"],
+                "Original Release": [row["release_id"]],
+            }
+            for row in batch
+        ]
+        result = client.create_records(RECORDINGS_TABLE_ID, fields_list)
+        _check_response(result, "Phase 2 (create recordings)")
+        created = result["records"]
+        for j, rec in enumerate(created):  # type: ignore[union-attr]
+            batch[j]["recording_id"] = rec["id"]  # type: ignore[index]
+        typer.echo(
+            f"  Phase 2: created {len(created)}/{len(batch)} recordings"
+            f" (total {i + len(created)}/{len(pending)})",
+            err=True,
+        )
+
+
+def phase3_update_releases(
+    client: AirtableClient,
+    pending: list[dict[str, object]],
+) -> None:
+    """Patch each Release with its Recordings link."""
+    for i in range(0, len(pending), BATCH_SIZE):
+        batch = pending[i : i + BATCH_SIZE]
+        records = [
+            {"id": row["release_id"], "fields": {"Recordings": [row["recording_id"]]}}
+            for row in batch
+        ]
+        result = client.update_records(RELEASES_TABLE_ID, records)
+        _check_response(result, "Phase 3 (update releases)")
+        updated = result["records"]
+        typer.echo(
+            f"  Phase 3: updated {len(updated)}/{len(batch)} releases"
+            f" (total {i + len(updated)}/{len(pending)})",
+            err=True,
+        )
+
+
+def phase4_update_chevy(
+    client: AirtableClient,
+    pending: list[dict[str, object]],
+) -> None:
+    """Patch each Chevy row with its Recordings link."""
+    for i in range(0, len(pending), BATCH_SIZE):
+        batch = pending[i : i + BATCH_SIZE]
+        records = [
+            {"id": row["chevy_id"], "fields": {"Recordings": [row["recording_id"]]}}
+            for row in batch
+        ]
+        result = client.update_records(CHEVY_TABLE_ID, records)
+        _check_response(result, "Phase 4 (update Chevy rows)")
+        updated = result["records"]
+        typer.echo(
+            f"  Phase 4: updated {len(updated)}/{len(batch)} Chevy rows"
+            f" (total {i + len(updated)}/{len(pending)})",
+            err=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+def main(
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Print JSON preview to stdout; no API calls.",
+    ),
+    episodes: str | None = typer.Option(
+        None,
+        "--episodes",
+        help="Comma-separated episode numbers (e.g. '60' or '60,61,62'). Default: all unlinked rows.",
+    ),
+) -> None:
+    """Create Releases + Recordings for unlinked Chevy Showroom Dist Mgmt rows."""
+    project_root = Path(__file__).parent.parent
+    load_dotenv(project_root / ".env")
+    token = os.environ.get("AIRTABLE_API_TOKEN")
+    if not token:
+        typer.secho(
+            "AIRTABLE_API_TOKEN is not set — check your .env file.",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    client = AirtableClient(token=token, base_id=BASE_ID)
+
+    episode_filter = parse_episodes(episodes)
+    if episode_filter is not None:
+        typer.echo(f"Filtering to episodes: {sorted(episode_filter)}", err=True)
+    else:
+        typer.echo("Processing all unlinked rows.", err=True)
+
+    typer.echo("Fetching unlinked Chevy rows…", err=True)
+    unlinked = fetch_unlinked_chevy_rows(client, episode_filter)
+    typer.echo(f"  {len(unlinked)} unlinked rows found.", err=True)
+
+    pending = build_pending(unlinked)
+    skipped = len(unlinked) - len(pending)
+    if skipped:
+        typer.echo(f"  {skipped} rows skipped (missing required fields).", err=True)
+
+    if not pending:
+        typer.echo("0 rows need linking.", err=True)
+        return
+
+    if dry_run:
+        json.dump(pending, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    typer.echo(f"Processing {len(pending)} rows in 4 phases…", err=True)
+    phase1_create_releases(client, pending)
+    phase2_create_recordings(client, pending)
+    phase3_update_releases(client, pending)
+    phase4_update_chevy(client, pending)
+    typer.echo(f"Done. {len(pending)} rows linked.", err=True)
+
+
+if __name__ == "__main__":
+    app()

--- a/scripts/patch_chevy_featured_artists.py
+++ b/scripts/patch_chevy_featured_artists.py
@@ -1,0 +1,335 @@
+"""Resolve Chevy Showroom featured artist names to Artist record IDs and patch
+linked Releases and Recordings.
+
+Chevy rows store guest artists as text names in a Multiple select field
+("Featured Artist"). The linked Releases and Recordings have Link-to-record
+fields that need real Artist record IDs. This script bridges the gap.
+
+Traversal:
+  Chevy rows → Release field     → Releases   → patch "Featured Artist(s)"
+  Chevy rows → Recordings field  → Recordings → patch "Featured Artist"
+
+Idempotent: existing artist IDs are read and merged; only new IDs trigger a
+PATCH call.
+
+Usage:
+    uv run python scripts/patch_chevy_featured_artists.py --dry-run
+    uv run python scripts/patch_chevy_featured_artists.py --episodes 60,61,62
+    uv run python scripts/patch_chevy_featured_artists.py   # all rows
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import typer
+from dotenv import load_dotenv
+
+from airtable_tui.api import AirtableClient
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+BASE_ID = "appEurfA8kXQE3slK"
+CHEVY_TABLE_ID = "tblRqFtQrPCNB1fwT"
+RELEASES_TABLE_ID = "tbl7rjVKUd5faZ7fV"
+RECORDINGS_TABLE_ID = "tblESvQQmOBbEXAH0"
+ARTISTS_TABLE_ID = "tbla7zxpHm76x0Aj9"
+
+# Field names used in PATCH payloads
+RELEASES_FA_FIELD = "Featured Artist(s)"
+RECORDINGS_FA_FIELD = "Featured Artist"
+
+BATCH_SIZE = 10
+
+app = typer.Typer(add_completion=False)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def list_all_records(client: AirtableClient, table_id: str) -> list[dict[str, object]]:
+    """Fetch every record from *table_id*, following AirTable's offset pagination."""
+    all_records: list[dict[str, object]] = []
+    offset = ""
+    while True:
+        result = client.list_records(table_id, offset=offset)
+        records = result.get("records")
+        if isinstance(records, list):
+            all_records.extend(records)  # type: ignore[arg-type]
+        next_offset = result.get("offset")
+        if not next_offset:
+            break
+        offset = str(next_offset)
+    return all_records
+
+
+def parse_episodes(value: str | None) -> set[int] | None:
+    if value is None:
+        return None
+    result: set[int] = set()
+    for part in value.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            result.add(int(part))
+        except ValueError:
+            typer.secho(f"Invalid episode number: {part!r}", fg=typer.colors.RED, err=True)
+            raise typer.Exit(1)
+    return result
+
+
+def build_artist_name_map(client: AirtableClient) -> dict[str, str]:
+    """Return lowercased name → record_id for every Artist record.
+
+    Warns on name collisions (keeps first occurrence).
+    """
+    typer.echo("Fetching all Artist records to build name map…", err=True)
+    records = list_all_records(client, ARTISTS_TABLE_ID)
+    typer.echo(f"  {len(records)} Artist records found.", err=True)
+
+    name_map: dict[str, str] = {}
+    for rec in records:
+        record_id = rec.get("id")
+        fields = rec.get("fields")
+        if not isinstance(record_id, str) or not isinstance(fields, dict):
+            continue
+        name = fields.get("Name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        key = name.strip().lower()
+        if key in name_map:
+            typer.secho(
+                f"  WARNING: duplicate artist name {name!r} — keeping {name_map[key]}, ignoring {record_id}",
+                fg=typer.colors.YELLOW,
+                err=True,
+            )
+        else:
+            name_map[key] = record_id
+    return name_map
+
+
+def resolve_artist_names(
+    names: list[str],
+    name_map: dict[str, str],
+    context: str,
+) -> list[str]:
+    """Resolve a list of text names to Artist record IDs.
+
+    Warns for each unresolved name and returns only the successfully resolved IDs.
+    """
+    resolved: list[str] = []
+    for name in names:
+        key = name.strip().lower()
+        record_id = name_map.get(key)
+        if record_id is None:
+            typer.secho(
+                f"  WARNING: unresolved artist name {name!r} in {context} — skipping",
+                fg=typer.colors.YELLOW,
+                err=True,
+            )
+        else:
+            resolved.append(record_id)
+    return resolved
+
+
+def accumulate_patches(
+    chevy_records: list[dict[str, object]],
+    episode_filter: set[int] | None,
+    name_map: dict[str, str],
+) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    """Walk qualifying Chevy rows and accumulate artist IDs per Release/Recording.
+
+    Returns (release_patches, recording_patches) where each is a dict from
+    record_id → set of artist record IDs that should appear in that record.
+    """
+    release_patches: dict[str, set[str]] = {}
+    recording_patches: dict[str, set[str]] = {}
+
+    for rec in chevy_records:
+        fields = rec.get("fields")
+        if not isinstance(fields, dict):
+            continue
+
+        if episode_filter is not None:
+            ep_str = str(fields.get("Episode #", "")).strip()
+            try:
+                ep_num = int(ep_str)
+            except ValueError:
+                continue
+            if ep_num not in episode_filter:
+                continue
+
+        raw_artists = fields.get("Featured Artist")
+        if not raw_artists:
+            continue
+        if not isinstance(raw_artists, list):
+            continue
+
+        context = f"Chevy row {rec.get('id', '?')} (ep {fields.get('Episode #', '?')})"
+        artist_ids = resolve_artist_names(raw_artists, name_map, context)  # type: ignore[arg-type]
+        if not artist_ids:
+            continue
+
+        for release_id in fields.get("Release", []):  # type: ignore[union-attr]
+            if isinstance(release_id, str):
+                release_patches.setdefault(release_id, set()).update(artist_ids)
+
+        for recording_id in fields.get("Recordings", []):  # type: ignore[union-attr]
+            if isinstance(recording_id, str):
+                recording_patches.setdefault(recording_id, set()).update(artist_ids)
+
+    return release_patches, recording_patches
+
+
+def build_patch_list(
+    client: AirtableClient,
+    table_id: str,
+    patches: dict[str, set[str]],
+    fa_field: str,
+    table_label: str,
+) -> list[dict[str, object]]:
+    """For each record, fetch existing Featured Artist IDs and merge with new ones.
+
+    Returns only records where the merged set is larger than the existing set
+    (i.e. there are genuinely new IDs to add).
+    """
+    result: list[dict[str, object]] = []
+    for record_id, new_ids in patches.items():
+        rec = client.retrieve_record(table_id, record_id)
+        fields = rec.get("fields")
+        if not isinstance(fields, dict):
+            typer.secho(
+                f"  WARNING: could not read fields for {table_label}/{record_id}",
+                fg=typer.colors.YELLOW,
+                err=True,
+            )
+            continue
+
+        existing: list[str] = fields.get(fa_field, [])  # type: ignore[assignment]
+        if not isinstance(existing, list):
+            existing = []
+
+        existing_set = set(existing)
+        merged = existing_set | new_ids
+
+        if merged == existing_set:
+            # Nothing to add
+            continue
+
+        result.append({"id": record_id, "fields": {fa_field: sorted(merged)}})
+    return result
+
+
+def apply_patches(
+    client: AirtableClient,
+    table_id: str,
+    patches: list[dict[str, object]],
+    table_label: str,
+) -> None:
+    """Batch-PATCH records in groups of BATCH_SIZE."""
+    total = len(patches)
+    updated = 0
+    for i in range(0, total, BATCH_SIZE):
+        batch = patches[i : i + BATCH_SIZE]
+        result = client.update_records(table_id, batch)
+        if "error" in result:
+            typer.secho(
+                f"  AirTable error patching {table_label}: {result['error']}",
+                fg=typer.colors.RED,
+                err=True,
+            )
+            raise typer.Exit(1)
+        n = len(result.get("records", []))  # type: ignore[arg-type]
+        updated += n
+        typer.echo(f"  {table_label}: patched {updated}/{total}", err=True)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+def main(
+    dry_run: bool = typer.Option(False, "--dry-run", help="Print patch plan to stdout; no API writes."),
+    episodes: str | None = typer.Option(
+        None,
+        "--episodes",
+        help="Comma-separated episode numbers to process (e.g. '60' or '60,61'). Default: all rows.",
+    ),
+) -> None:
+    """Patch Featured Artist links on Releases and Recordings linked from Chevy rows."""
+    project_root = Path(__file__).parent.parent
+    load_dotenv(project_root / ".env")
+    token = os.environ.get("AIRTABLE_API_TOKEN")
+    if not token:
+        typer.secho("AIRTABLE_API_TOKEN is not set — check your .env file.", fg=typer.colors.RED, err=True)
+        raise typer.Exit(1)
+
+    client = AirtableClient(token=token, base_id=BASE_ID)
+
+    episode_filter = parse_episodes(episodes)
+    if episode_filter is not None:
+        typer.echo(f"Filtering to episodes: {sorted(episode_filter)}", err=True)
+
+    # Step 1 — build name map
+    name_map = build_artist_name_map(client)
+
+    # Step 2 — fetch Chevy rows
+    typer.echo("Fetching all Chevy Showroom Dist Mgmt rows…", err=True)
+    chevy_records = list_all_records(client, CHEVY_TABLE_ID)
+    typer.echo(f"  {len(chevy_records)} rows found.", err=True)
+
+    # Step 3 — accumulate patches
+    release_acc, recording_acc = accumulate_patches(chevy_records, episode_filter, name_map)
+    typer.echo(
+        f"  {len(release_acc)} Releases and {len(recording_acc)} Recordings have featured artists to check.",
+        err=True,
+    )
+
+    # Step 4 — idempotency check: build final patch lists
+    typer.echo("Checking Releases for missing Featured Artist links…", err=True)
+    release_patches = build_patch_list(client, RELEASES_TABLE_ID, release_acc, RELEASES_FA_FIELD, "Releases")
+    typer.echo(f"  {len(release_patches)} Releases need patching.", err=True)
+
+    typer.echo("Checking Recordings for missing Featured Artist links…", err=True)
+    recording_patches = build_patch_list(client, RECORDINGS_TABLE_ID, recording_acc, RECORDINGS_FA_FIELD, "Recordings")
+    typer.echo(f"  {len(recording_patches)} Recordings need patching.", err=True)
+
+    if not release_patches and not recording_patches:
+        typer.echo("All records already have correct Featured Artist links. Nothing to do.", err=True)
+        return
+
+    if dry_run:
+        json.dump(
+            {"releases": release_patches, "recordings": recording_patches},
+            sys.stdout,
+            indent=2,
+        )
+        sys.stdout.write("\n")
+        return
+
+    # Step 5 — apply patches
+    if release_patches:
+        typer.echo(f"Patching {len(release_patches)} Releases…", err=True)
+        apply_patches(client, RELEASES_TABLE_ID, release_patches, "Releases")
+
+    if recording_patches:
+        typer.echo(f"Patching {len(recording_patches)} Recordings…", err=True)
+        apply_patches(client, RECORDINGS_TABLE_ID, recording_patches, "Recordings")
+
+    typer.echo(
+        f"Done. {len(release_patches)} Releases and {len(recording_patches)} Recordings updated.",
+        err=True,
+    )
+
+
+if __name__ == "__main__":
+    app()

--- a/scripts/patch_chevy_primary_artist.py
+++ b/scripts/patch_chevy_primary_artist.py
@@ -1,0 +1,258 @@
+"""Set Primary Artist = Pat Boone on all Releases and Recordings linked from
+Chevy Showroom Dist Mgmt rows.
+
+Pat Boone's AirTable artist record ID: recLWgt9qnlgDkkAo
+
+Traversal:
+  Chevy rows → Release field  → Releases  → patch Primary Artist if missing
+  Chevy rows → Recordings field → Recordings → patch Primary Artist if missing
+
+Idempotent: records that already have Pat Boone as Primary Artist are skipped.
+Records that already have a *different* Primary Artist are logged as warnings and
+still patched (the user's intent is that every Chevy Release/Recording belongs
+to Pat Boone).
+
+Usage:
+    uv run python scripts/patch_chevy_primary_artist.py --dry-run
+    uv run python scripts/patch_chevy_primary_artist.py --episodes 60
+    uv run python scripts/patch_chevy_primary_artist.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import typer
+from dotenv import load_dotenv
+
+from airtable_tui.api import AirtableClient
+
+CHEVY_TABLE_ID = "tblRqFtQrPCNB1fwT"
+RELEASES_TABLE_ID = "tbl7rjVKUd5faZ7fV"
+RECORDINGS_TABLE_ID = "tblESvQQmOBbEXAH0"
+BASE_ID = "appEurfA8kXQE3slK"
+
+PAT_BOONE_RECORD_ID = "recLWgt9qnlgDkkAo"
+BATCH_SIZE = 10
+
+app = typer.Typer(add_completion=False)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def list_all_records(client: AirtableClient, table_id: str) -> list[dict[str, object]]:
+    """Fetch every record from *table_id*, following AirTable's offset pagination."""
+    all_records: list[dict[str, object]] = []
+    offset = ""
+    while True:
+        result = client.list_records(table_id, offset=offset)
+        records = result.get("records")
+        if isinstance(records, list):
+            all_records.extend(records)  # type: ignore[arg-type]
+        next_offset = result.get("offset")
+        if not next_offset:
+            break
+        offset = str(next_offset)
+    return all_records
+
+
+def parse_episodes(value: str | None) -> set[int] | None:
+    if value is None:
+        return None
+    result: set[int] = set()
+    for part in value.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            result.add(int(part))
+        except ValueError:
+            typer.secho(f"Invalid episode number: {part!r}", fg=typer.colors.RED, err=True)
+            raise typer.Exit(1)
+    return result
+
+
+def collect_linked_ids(
+    chevy_records: list[dict[str, object]],
+    episode_filter: set[int] | None,
+) -> tuple[list[str], list[str]]:
+    """Return (release_ids, recording_ids) from Chevy rows, respecting episode filter.
+
+    Deduplicates IDs while preserving first-seen order.
+    """
+    seen_releases: set[str] = set()
+    seen_recordings: set[str] = set()
+    release_ids: list[str] = []
+    recording_ids: list[str] = []
+
+    for rec in chevy_records:
+        fields = rec.get("fields")
+        if not isinstance(fields, dict):
+            continue
+
+        if episode_filter is not None:
+            ep_str = str(fields.get("Episode #", "")).strip()
+            try:
+                ep_num = int(ep_str)
+            except ValueError:
+                continue
+            if ep_num not in episode_filter:
+                continue
+
+        for rid in fields.get("Release", []):  # type: ignore[union-attr]
+            if isinstance(rid, str) and rid not in seen_releases:
+                seen_releases.add(rid)
+                release_ids.append(rid)
+
+        for rid in fields.get("Recordings", []):  # type: ignore[union-attr]
+            if isinstance(rid, str) and rid not in seen_recordings:
+                seen_recordings.add(rid)
+                recording_ids.append(rid)
+
+    return release_ids, recording_ids
+
+
+def find_missing(
+    client: AirtableClient,
+    table_id: str,
+    record_ids: list[str],
+    table_label: str,
+) -> list[dict[str, object]]:
+    """Return patch dicts for records whose Primary Artist != Pat Boone.
+
+    Logs skips (already correct) and warnings (overwriting a different artist).
+    """
+    patches: list[dict[str, object]] = []
+
+    for record_id in record_ids:
+        rec = client.retrieve_record(table_id, record_id)
+        fields = rec.get("fields")
+        if not isinstance(fields, dict):
+            typer.secho(
+                f"  WARNING: could not read fields for {table_label}/{record_id}",
+                fg=typer.colors.YELLOW,
+                err=True,
+            )
+            continue
+
+        current: list[str] = fields.get("Primary Artist", [])  # type: ignore[assignment]
+        if isinstance(current, list) and PAT_BOONE_RECORD_ID in current:
+            # Already correct — skip
+            continue
+
+        if current:
+            typer.secho(
+                f"  OVERWRITING Primary Artist on {table_label}/{record_id}"
+                f" (was: {current})",
+                fg=typer.colors.YELLOW,
+                err=True,
+            )
+        patches.append({"id": record_id, "fields": {"Primary Artist": [PAT_BOONE_RECORD_ID]}})
+
+    return patches
+
+
+def apply_patches(
+    client: AirtableClient,
+    table_id: str,
+    patches: list[dict[str, object]],
+    table_label: str,
+) -> None:
+    """Batch-PATCH records in groups of BATCH_SIZE."""
+    total = len(patches)
+    updated = 0
+    for i in range(0, total, BATCH_SIZE):
+        batch = patches[i : i + BATCH_SIZE]
+        result = client.update_records(table_id, batch)
+        if "error" in result:
+            typer.secho(
+                f"  AirTable error patching {table_label}: {result['error']}",
+                fg=typer.colors.RED,
+                err=True,
+            )
+            raise typer.Exit(1)
+        n = len(result.get("records", []))  # type: ignore[arg-type]
+        updated += n
+        typer.echo(
+            f"  {table_label}: patched {updated}/{total}",
+            err=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+def main(
+    dry_run: bool = typer.Option(False, "--dry-run", help="Print patch plan to stdout; no API writes."),
+    episodes: str | None = typer.Option(
+        None,
+        "--episodes",
+        help="Comma-separated episode numbers to process (e.g. '60' or '60,61'). Default: all rows.",
+    ),
+) -> None:
+    """Ensure Pat Boone is Primary Artist on all Chevy-linked Releases and Recordings."""
+    project_root = Path(__file__).parent.parent
+    load_dotenv(project_root / ".env")
+    token = os.environ.get("AIRTABLE_API_TOKEN")
+    if not token:
+        typer.secho("AIRTABLE_API_TOKEN is not set — check your .env file.", fg=typer.colors.RED, err=True)
+        raise typer.Exit(1)
+
+    client = AirtableClient(token=token, base_id=BASE_ID)
+
+    episode_filter = parse_episodes(episodes)
+    if episode_filter is not None:
+        typer.echo(f"Filtering to episodes: {sorted(episode_filter)}", err=True)
+
+    typer.echo("Fetching all Chevy Showroom Dist Mgmt rows…", err=True)
+    chevy_records = list_all_records(client, CHEVY_TABLE_ID)
+    typer.echo(f"  {len(chevy_records)} rows found.", err=True)
+
+    release_ids, recording_ids = collect_linked_ids(chevy_records, episode_filter)
+    typer.echo(f"  {len(release_ids)} linked Releases, {len(recording_ids)} linked Recordings.", err=True)
+
+    typer.echo("Checking Releases for missing Primary Artist…", err=True)
+    release_patches = find_missing(client, RELEASES_TABLE_ID, release_ids, "Releases")
+    typer.echo(f"  {len(release_patches)} Releases need patching.", err=True)
+
+    typer.echo("Checking Recordings for missing Primary Artist…", err=True)
+    recording_patches = find_missing(client, RECORDINGS_TABLE_ID, recording_ids, "Recordings")
+    typer.echo(f"  {len(recording_patches)} Recordings need patching.", err=True)
+
+    if not release_patches and not recording_patches:
+        typer.echo("All records already have Pat Boone as Primary Artist. Nothing to do.", err=True)
+        return
+
+    if dry_run:
+        json.dump(
+            {"releases": release_patches, "recordings": recording_patches},
+            sys.stdout,
+            indent=2,
+        )
+        sys.stdout.write("\n")
+        return
+
+    if release_patches:
+        typer.echo(f"Patching {len(release_patches)} Releases…", err=True)
+        apply_patches(client, RELEASES_TABLE_ID, release_patches, "Releases")
+
+    if recording_patches:
+        typer.echo(f"Patching {len(recording_patches)} Recordings…", err=True)
+        apply_patches(client, RECORDINGS_TABLE_ID, recording_patches, "Recordings")
+
+    typer.echo(
+        f"Done. {len(release_patches)} Releases and {len(recording_patches)} Recordings updated.",
+        err=True,
+    )
+
+
+if __name__ == "__main__":
+    app()

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL="https://github.com/CraftBrewzMusic/AirTable_PBGL.git"
+
+say() {
+  printf '%s\n' "$1"
+}
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    say "Missing required command: $1"
+    exit 1
+  fi
+}
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+say "AirTable PBGL setup"
+say "This script installs dependencies and prepares a local .env file."
+
+need_cmd git
+need_cmd uv
+
+if [ ! -f "$ROOT/pyproject.toml" ]; then
+  say "This copy of setup.sh expects to run from a cloned AirTable_PBGL repo."
+  say "Clone the repo first with: git clone $REPO_URL"
+  exit 1
+fi
+
+cd "$ROOT"
+
+say "Syncing Python dependencies with uv..."
+uv sync
+
+if [ ! -f ".env" ] && [ -f ".env.example" ]; then
+  cp ".env.example" ".env"
+  say "Created .env from .env.example"
+fi
+
+say "Next step: add AIRTABLE_API_TOKEN to .env"
+say "Launch with: uv run atp"

--- a/src/atp/__init__.py
+++ b/src/atp/__init__.py
@@ -1,0 +1,5 @@
+"""AirTable PBGL package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/src/atp/api.py
+++ b/src/atp/api.py
@@ -1,0 +1,109 @@
+"""Requests-based AirTable API client."""
+from __future__ import annotations
+
+import time
+from collections import deque
+
+import requests
+
+
+class AirtableClient:
+    BASE_URL = "https://api.airtable.com/v0"
+    _RATE_LIMIT = 5  # max requests per second
+
+    def __init__(
+        self,
+        token: str,
+        base_id: str,
+        session: requests.Session | None = None,
+        timeout: int = 30,
+    ) -> None:
+        self.base_id = base_id
+        self._timeout = timeout
+        self._session = session or requests.Session()
+        self._session.headers.update({
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        })
+        # GET-only response cache; keyed on (url, *sorted_params).
+        self._cache: dict[tuple[str, ...], dict[str, object]] = {}
+        # Timestamps of the last _RATE_LIMIT requests (monotonic seconds).
+        self._timestamps: deque[float] = deque(maxlen=self._RATE_LIMIT)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _throttle(self) -> None:
+        """Block until sending one more request won't exceed the rate limit."""
+        if len(self._timestamps) == self._RATE_LIMIT:
+            wait = 1.0 - (time.monotonic() - self._timestamps[0])
+            if wait > 0:
+                time.sleep(wait)
+        self._timestamps.append(time.monotonic())
+
+    def _cache_key(self, url: str, params: dict[str, str | int] | None) -> tuple[str, ...]:
+        if not params:
+            return (url,)
+        return (url,) + tuple(sorted((str(k), str(v)) for k, v in params.items()))
+
+    def _get(self, url: str, params: dict[str, str | int] | None = None) -> dict[str, object]:
+        """GET with caching and rate-limiting."""
+        key = self._cache_key(url, params)
+        if key in self._cache:
+            return self._cache[key]
+        self._throttle()
+        result: dict[str, object] = self._session.get(url, params=params, timeout=self._timeout).json()  # type: ignore[no-any-return]
+        self._cache[key] = result
+        return result
+
+    def _url(self, table_id: str) -> str:
+        return f"{self.BASE_URL}/{self.base_id}/{table_id}"
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def list_records(
+        self,
+        table_id: str,
+        filter_formula: str = "",
+        max_records: int = 0,
+        view: str = "",
+        offset: str = "",
+    ) -> dict[str, object]:
+        params: dict[str, str | int] = {}
+        if filter_formula:
+            params["filterByFormula"] = filter_formula
+        if max_records > 0:
+            params["maxRecords"] = max_records
+        if view:
+            params["view"] = view
+        if offset:
+            params["offset"] = offset
+        return self._get(self._url(table_id), params or None)
+
+    def retrieve_record(self, table_id: str, record_id: str) -> dict[str, object]:
+        return self._get(f"{self._url(table_id)}/{record_id}")
+
+    def create_records(
+        self,
+        table_id: str,
+        fields_list: list[dict[str, object]],
+        typecast: bool = False,
+    ) -> dict[str, object]:
+        self._throttle()
+        body: dict[str, object] = {"records": [{"fields": f} for f in fields_list]}
+        if typecast:
+            body["typecast"] = True
+        return self._session.post(self._url(table_id), json=body, timeout=self._timeout).json()  # type: ignore[no-any-return]
+
+    def update_records(self, table_id: str, records: list[dict[str, object]]) -> dict[str, object]:
+        """records: [{"id": "recXXX", "fields": {...}}, ...]"""
+        self._throttle()
+        return self._session.patch(self._url(table_id), json={"records": records}, timeout=self._timeout).json()  # type: ignore[no-any-return]
+
+    def delete_records(self, table_id: str, record_ids: list[str]) -> dict[str, object]:
+        self._throttle()
+        params = [("records[]", rid) for rid in record_ids]
+        return self._session.delete(self._url(table_id), params=params, timeout=self._timeout).json()  # type: ignore[no-any-return]

--- a/src/atp/app.py
+++ b/src/atp/app.py
@@ -1,0 +1,542 @@
+"""Textual TUI for AirTable CRUD operations."""
+from __future__ import annotations
+
+import json
+from typing import override
+
+import requests
+from textual import on
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.css.query import NoMatches
+from textual.widget import Widget
+from textual.widgets import (
+    Button,
+    Checkbox,
+    Footer,
+    Header,
+    Input,
+    Label,
+    ListItem,
+    ListView,
+    Static,
+    TextArea,
+)
+
+from .api import AirtableClient
+from .config import DEFAULT_EXPAND_DEPTH
+from .md_parser import TableInfo, find_md_dir, load_tables, writable_fields
+
+_TABLE_DISPLAY_NAMES: dict[str, str] = {
+    "REGISTRATION PROJECT (PRO +MLC)": "Reg: PRO + MLC",
+    "REGISTRATION PROJECT (SOUNDEXCHANGE)": "Reg: SoundExchange",
+}
+
+_OPERATIONS = [
+    ("list", "List Records"),
+    ("retrieve", "Retrieve Record"),
+    ("create", "Create Record"),
+    ("update", "Update Record"),
+    ("delete", "Delete Record(s)"),
+]
+
+
+class AirtableTUI(App[None]):
+    TITLE = "AirTable PBGL"
+    SUB_TITLE = "ATP: AirTable PBGL"
+
+    CSS = """
+    Screen {
+        layout: horizontal;
+    }
+
+    #tables-pane {
+        width: 22;
+        height: 100%;
+        border: solid $primary;
+    }
+
+    #ops-pane {
+        width: 26;
+        height: 100%;
+        border: solid $primary;
+    }
+
+    #params-pane {
+        width: 1fr;
+        height: 100%;
+        border: solid $primary;
+        layout: vertical;
+    }
+
+    .pane-title {
+        background: $primary;
+        color: $background;
+        padding: 0 1;
+        text-align: center;
+        height: 1;
+        width: 100%;
+    }
+
+    ListView {
+        height: 1fr;
+    }
+
+    #params-inputs {
+        height: 40%;
+        width: 100%;
+        padding: 0 1;
+    }
+
+    .param-label {
+        margin-top: 1;
+        height: 1;
+        color: $text-muted;
+    }
+
+    #btn-row {
+        height: auto;
+        margin: 1 2;
+    }
+
+    #btn-row Button {
+        width: 1fr;
+        margin: 0 1;
+    }
+
+    #response-area {
+        height: 1fr;
+        width: 100%;
+    }
+
+    #copy-response-btn {
+        width: 100%;
+        height: auto;
+        margin: 0;
+    }
+    """
+
+    BINDINGS = [
+        Binding("q", "quit", "Quit"),
+        Binding("ctrl+r", "refresh_tables", "Refresh"),
+    ]
+
+    @override
+    def __init__(self, token: str = "") -> None:
+        super().__init__()
+        self._token = token
+        self._tables: list[TableInfo] = []
+        self._selected_table: TableInfo | None = None
+        self._selected_op: str | None = None
+        self._client: AirtableClient | None = None
+
+    @override
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Horizontal():
+            with Vertical(id="tables-pane"):
+                yield Label("Tables", classes="pane-title")
+                yield ListView(id="tables-list")
+            with Vertical(id="ops-pane"):
+                yield Label("Operations", classes="pane-title")
+                yield ListView(id="ops-list")
+            with Vertical(id="params-pane"):
+                yield Label("Params / Response", classes="pane-title")
+                with VerticalScroll(id="params-inputs"):
+                    yield Static("← Select a table and operation", id="params-hint")
+                with Horizontal(id="btn-row"):
+                    yield Button("Execute", id="execute-btn", variant="primary", disabled=True)
+                    yield Button("Copy as curl", id="copy-curl-btn", disabled=True)
+                    yield Button("Copy as CLI", id="copy-cli-btn", disabled=True)
+                yield TextArea(
+                    "",
+                    id="response-area",
+                    read_only=True,
+                    show_line_numbers=False,
+                    language="json",
+                )
+                yield Button("Copy response", id="copy-response-btn")
+        yield Footer()
+
+    @override
+    def on_mount(self) -> None:
+        self._load_data()
+
+    def _load_data(self) -> None:
+        self._tables = load_tables(find_md_dir())
+
+        tables_list = self.query_one("#tables-list", ListView)
+        for table in self._tables:
+            display = _TABLE_DISPLAY_NAMES.get(table["name"], table["name"])
+            tables_list.append(ListItem(Label(display)))
+
+        if self._tables and self._token:
+            base_id = self._tables[0]["base_id"]
+            self._client = AirtableClient(token=self._token, base_id=base_id)
+        elif not self._token:
+            self.notify(
+                "AIRTABLE_API_TOKEN not set — add it to .env or set the env var.",
+                severity="warning",
+                timeout=8,
+            )
+
+    @on(ListView.Selected, "#tables-list")
+    async def _on_table_selected(self, event: ListView.Selected) -> None:
+        idx = event.list_view.index
+        if idx is None or idx >= len(self._tables):
+            return
+        self._selected_table = self._tables[idx]
+        self._selected_op = None
+
+        ops_list = self.query_one("#ops-list", ListView)
+        ops_list.clear()
+        for _, label in _OPERATIONS:
+            ops_list.append(ListItem(Label(label)))
+
+        await self._clear_params()
+        for btn_id in ("#execute-btn", "#copy-curl-btn", "#copy-cli-btn"):
+            self.query_one(btn_id, Button).disabled = True
+
+    @on(ListView.Selected, "#ops-list")
+    async def _on_op_selected(self, event: ListView.Selected) -> None:
+        if self._selected_table is None:
+            return
+        idx = event.list_view.index
+        if idx is None or idx >= len(_OPERATIONS):
+            return
+        self._selected_op = _OPERATIONS[idx][0]
+        await self._build_params()
+        for btn_id in ("#execute-btn", "#copy-curl-btn", "#copy-cli-btn"):
+            self.query_one(btn_id, Button).disabled = False
+
+    async def _clear_params(self) -> None:
+        container = self.query_one("#params-inputs", VerticalScroll)
+        await container.remove_children()
+        await container.mount(Static("← Select an operation", id="params-hint"))
+
+    async def _build_params(self) -> None:
+        container = self.query_one("#params-inputs", VerticalScroll)
+        await container.remove_children()
+        widgets = self._make_param_widgets()
+        if widgets:
+            await container.mount(*widgets)
+
+    def _make_param_widgets(self) -> list[Widget]:
+        op = self._selected_op
+        table = self._selected_table
+        assert table is not None
+
+        if op == "list":
+            return [
+                Label("filterByFormula (optional):", classes="param-label"),
+                Input(placeholder="e.g. {Name}='John'", id="param-filter"),
+                Label("maxRecords (optional):", classes="param-label"),
+                Input(placeholder="e.g. 10", id="param-max-records"),
+                Label("view (optional):", classes="param-label"),
+                Input(placeholder="e.g. Default", id="param-view"),
+                Label("Expand linked records:", classes="param-label"),
+                Checkbox("Expand", id="param-expand"),
+                Label("Depth (default 5):", classes="param-label"),
+                Input(value="5", placeholder="5", id="param-depth"),
+            ]
+
+        if op == "retrieve":
+            return [
+                Label("Record ID (required):", classes="param-label"),
+                Input(placeholder="recXXXXXXXXXXXXXX", id="param-record-id"),
+                Label("Expand linked records:", classes="param-label"),
+                Checkbox("Expand", id="param-expand"),
+                Label("Depth (default 5):", classes="param-label"),
+                Input(value="5", placeholder="5", id="param-depth"),
+            ]
+
+        if op == "create":
+            widgets: list[Widget] = []
+            for field in writable_fields(table):
+                widgets.append(Label(f"{field['name']} ({field['type']}):", classes="param-label"))
+                widgets.append(Input(placeholder="", id=f"param-field-{field['field_id']}"))
+            widgets.append(Label("Apply live changes:", classes="param-label"))
+            widgets.append(Checkbox("Apply now", id="param-apply"))
+            return widgets
+
+        if op == "update":
+            widgets = [
+                Label("Record ID (required):", classes="param-label"),
+                Input(placeholder="recXXXXXXXXXXXXXX", id="param-record-id"),
+            ]
+            for field in writable_fields(table):
+                widgets.append(
+                    Label(
+                        f"{field['name']} ({field['type']}) – leave empty to skip:",
+                        classes="param-label",
+                    )
+                )
+                widgets.append(Input(placeholder="", id=f"param-field-{field['field_id']}"))
+            widgets.append(Label("Apply live changes:", classes="param-label"))
+            widgets.append(Checkbox("Apply now", id="param-apply"))
+            return widgets
+
+        if op == "delete":
+            return [
+                Label("Record ID(s), comma-separated:", classes="param-label"),
+                Input(placeholder="recXXXX, recYYYY", id="param-record-ids"),
+                Label("Apply live changes:", classes="param-label"),
+                Checkbox("Apply now", id="param-apply"),
+            ]
+
+        return []
+
+    @on(Button.Pressed, "#execute-btn")
+    def _on_execute(self, _event: Button.Pressed) -> None:
+        if self._selected_op in {"list", "retrieve"} and self._client is None:
+            self.notify("API token not configured!", severity="error")
+            return
+        if self._selected_op in {"create", "update", "delete"} and self._apply_enabled() and self._client is None:
+            self.notify("API token not configured!", severity="error")
+            return
+        if self._selected_table is None or self._selected_op is None:
+            return
+
+        response_area = self.query_one("#response-area", TextArea)
+        response_area.load_text("Requesting…")
+
+        try:
+            result = self._call_api(self._selected_table, self._selected_op)
+            response_area.load_text(json.dumps(result, indent=2))
+        except requests.exceptions.RequestException as exc:
+            response_area.load_text(f"Error: {exc}")
+
+    def _call_api(self, table: TableInfo, op: str) -> dict[str, object]:
+        tid = table["table_id"] or table["name"]
+
+        if op == "list":
+            assert self._client is not None
+            result = self._client.list_records(
+                tid,
+                filter_formula=self._input_val("#param-filter"),
+                max_records=self._int_input("#param-max-records"),
+                view=self._input_val("#param-view"),
+            )
+            if self._expand_enabled():
+                from .expand import expand_api_response
+                depth = self._int_input("#param-depth") or DEFAULT_EXPAND_DEPTH
+                result = expand_api_response(result, tid, self._tables, self._client, depth)  # type: ignore[arg-type]
+            return result
+
+        if op == "retrieve":
+            assert self._client is not None
+            result = self._client.retrieve_record(tid, self._input_val("#param-record-id"))
+            if self._expand_enabled():
+                from .expand import expand_api_response
+                depth = self._int_input("#param-depth") or DEFAULT_EXPAND_DEPTH
+                result = expand_api_response(result, tid, self._tables, self._client, depth)  # type: ignore[arg-type]
+            return result
+
+        if op == "create":
+            fields_dict: dict[str, str] = {}
+            for field in writable_fields(table):
+                val = self._input_val(f"#param-field-{field['field_id']}")
+                if val:
+                    fields_dict[field["name"]] = val
+            if not self._apply_enabled():
+                return self._preview_payload(table, op, {"records": [{"fields": fields_dict}]})
+            assert self._client is not None
+            return self._client.create_records(tid, [fields_dict])
+
+        if op == "update":
+            record_id = self._input_val("#param-record-id")
+            fields_dict = {}
+            for field in writable_fields(table):
+                val = self._input_val(f"#param-field-{field['field_id']}")
+                if val:
+                    fields_dict[field["name"]] = val
+            if not self._apply_enabled():
+                return self._preview_payload(table, op, {"records": [{"id": record_id, "fields": fields_dict}]})
+            assert self._client is not None
+            return self._client.update_records(tid, [{"id": record_id, "fields": fields_dict}])
+
+        if op == "delete":
+            ids_raw = self._input_val("#param-record-ids")
+            ids = [rid.strip() for rid in ids_raw.split(",") if rid.strip()]
+            if not self._apply_enabled():
+                return self._preview_payload(table, op, {"records": ids})
+            assert self._client is not None
+            return self._client.delete_records(tid, ids)
+
+        return {}
+
+    def _expand_enabled(self) -> bool:
+        try:
+            return self.query_one("#param-expand", Checkbox).value
+        except NoMatches:
+            return False
+
+    def _apply_enabled(self) -> bool:
+        try:
+            return self.query_one("#param-apply", Checkbox).value
+        except NoMatches:
+            return False
+
+    def _preview_payload(self, table: TableInfo, op: str, payload: dict[str, object]) -> dict[str, object]:
+        return {
+            "action": op,
+            "apply": False,
+            "table": table["name"],
+            "table_id": table["table_id"] or table["name"],
+            "payload": payload,
+        }
+
+    def _input_val(self, selector: str) -> str:
+        try:
+            return self.query_one(selector, Input).value
+        except NoMatches:
+            return ""
+
+    def _int_input(self, selector: str) -> int:
+        val = self._input_val(selector).strip()
+        return int(val) if val.isdigit() else 0
+
+    @on(Button.Pressed, "#copy-response-btn")
+    def _on_copy_response(self, _event: Button.Pressed) -> None:
+        text = self.query_one("#response-area", TextArea).text
+        if text.strip():
+            self.copy_to_clipboard(text)
+            self.notify("Response copied to clipboard.", timeout=2)
+
+    @on(Button.Pressed, "#copy-curl-btn")
+    def _on_copy_curl(self, _event: Button.Pressed) -> None:
+        cmd = self._build_curl()
+        if cmd:
+            self.copy_to_clipboard(cmd)
+            self.notify("curl command copied to clipboard.", timeout=2)
+
+    @on(Button.Pressed, "#copy-cli-btn")
+    def _on_copy_cli(self, _event: Button.Pressed) -> None:
+        cmd = self._build_cli_command()
+        if cmd:
+            self.copy_to_clipboard(cmd)
+            self.notify("CLI command copied to clipboard.", timeout=2)
+
+    def _build_curl(self) -> str:
+        table = self._selected_table
+        op = self._selected_op
+        if not table or not op:
+            return ""
+
+        tid = table["table_id"] or table["name"]
+        base_url = f"https://api.airtable.com/v0/{table['base_id']}/{tid}"
+        auth = '-H "Authorization: Bearer $AIRTABLE_API_TOKEN"'
+        ct = '-H "Content-Type: application/json"'
+
+        if op == "list":
+            params = []
+            if f := self._input_val("#param-filter"):
+                params.append(f"filterByFormula={f}")
+            if m := self._input_val("#param-max-records"):
+                params.append(f"maxRecords={m}")
+            if v := self._input_val("#param-view"):
+                params.append(f"view={v}")
+            qs = ("?" + "&".join(params)) if params else ""
+            return f'curl "{base_url}{qs}" \\\n  {auth}'
+
+        if op == "retrieve":
+            rid = self._input_val("#param-record-id")
+            return f'curl "{base_url}/{rid}" \\\n  {auth}'
+
+        if op == "create":
+            fields_dict = {
+                field["name"]: val
+                for field in writable_fields(table)
+                if (val := self._input_val(f"#param-field-{field['field_id']}"))
+            }
+            body = json.dumps({"records": [{"fields": fields_dict}]})
+            return f'curl -X POST "{base_url}" \\\n  {auth} \\\n  {ct} \\\n  -d \'{body}\''
+
+        if op == "update":
+            rid = self._input_val("#param-record-id")
+            fields_dict = {
+                field["name"]: val
+                for field in writable_fields(table)
+                if (val := self._input_val(f"#param-field-{field['field_id']}"))
+            }
+            body = json.dumps({"records": [{"id": rid, "fields": fields_dict}]})
+            return f'curl -X PATCH "{base_url}" \\\n  {auth} \\\n  {ct} \\\n  -d \'{body}\''
+
+        if op == "delete":
+            ids_raw = self._input_val("#param-record-ids")
+            ids = [r.strip() for r in ids_raw.split(",") if r.strip()]
+            qs = "?" + "&".join(f"records[]={r}" for r in ids) if ids else ""
+            return f'curl -X DELETE "{base_url}{qs}" \\\n  {auth}'
+
+        return ""
+
+    def _build_cli_command(self) -> str:
+        table = self._selected_table
+        op = self._selected_op
+        if not table or not op:
+            return ""
+
+        name = table["name"]
+        t_arg = f'"{name}"' if " " in name else name
+
+        if op == "list":
+            parts = [f"atp records list {t_arg}"]
+            if f := self._input_val("#param-filter"):
+                parts.append(f'--filter "{f}"')
+            if m := self._input_val("#param-max-records"):
+                parts.append(f"--max-records {m}")
+            if v := self._input_val("#param-view"):
+                parts.append(f'--view "{v}"')
+            if self._expand_enabled():
+                parts.append("--expand")
+                if (d := self._int_input("#param-depth")) and d != 5:
+                    parts.append(f"--depth {d}")
+            return " ".join(parts)
+
+        if op == "retrieve":
+            rid = self._input_val("#param-record-id")
+            cmd = f"atp records retrieve {t_arg} {rid}"
+            if self._expand_enabled():
+                cmd += " --expand"
+                if (d := self._int_input("#param-depth")) and d != 5:
+                    cmd += f" --depth {d}"
+            return cmd
+
+        if op == "create":
+            parts = [f"atp records create {t_arg}"]
+            for field in writable_fields(table):
+                if val := self._input_val(f"#param-field-{field['field_id']}"):
+                    parts.append(f'--field "{field["name"]}={val}"')
+            if self._apply_enabled():
+                parts.append("--apply")
+            return " ".join(parts)
+
+        if op == "update":
+            rid = self._input_val("#param-record-id")
+            parts = [f"atp records update {t_arg} {rid}"]
+            for field in writable_fields(table):
+                if val := self._input_val(f"#param-field-{field['field_id']}"):
+                    parts.append(f'--field "{field["name"]}={val}"')
+            if self._apply_enabled():
+                parts.append("--apply")
+            return " ".join(parts)
+
+        if op == "delete":
+            ids_raw = self._input_val("#param-record-ids")
+            ids = [r.strip() for r in ids_raw.split(",") if r.strip()]
+            cmd = f"atp records delete {t_arg} {' '.join(ids)}"
+            if self._apply_enabled():
+                cmd += " --apply"
+            return cmd
+
+        return ""
+
+    def action_refresh_tables(self) -> None:
+        tables_list = self.query_one("#tables-list", ListView)
+        tables_list.clear()
+        self._tables = load_tables(find_md_dir())
+        for table in self._tables:
+            display = _TABLE_DISPLAY_NAMES.get(table["name"], table["name"])
+            tables_list.append(ListItem(Label(display)))
+        self.notify("Tables refreshed.", timeout=2)

--- a/src/atp/chevy_import_songs.py
+++ b/src/atp/chevy_import_songs.py
@@ -1,0 +1,176 @@
+"""Import Pat Boone Chevy Showroom songs from song_index.csv into AirTable.
+
+Usage:
+    uv run python scripts/import_chevy_songs.py [--dry-run]
+    uv run python scripts/import_chevy_songs.py --episodes 60
+    uv run python scripts/import_chevy_songs.py --episodes 60,61,62
+"""
+from __future__ import annotations
+
+import csv
+from datetime import datetime
+from pathlib import Path
+
+import typer
+
+from .api import AirtableClient
+from .common import emit_json, list_all_records, parse_episode_filter, require_token
+from .config import BASE_ID, CHEVY_TABLE_ID, DEFAULT_CHEVY_CSV_PATH, DEFAULT_MIN_CHEVY_EPISODE
+
+# CSV column positions (header has a duplicate "guest_artists" column — use positional access)
+COL_EPISODE = 0
+COL_TRACK = 1
+COL_TITLE = 2
+COL_DATE = 3
+COL_GUEST = 4
+
+def parse_iso_date(s: str) -> str:
+    """'October 3, 1957' → '1957-10-03'."""
+    return datetime.strptime(s.strip(), "%B %d, %Y").strftime("%Y-%m-%d")
+
+
+def format_long_date(s: str) -> str:
+    """'October 3, 1957' → 'October 3, 1957' (no leading zero on day)."""
+    dt = datetime.strptime(s.strip(), "%B %d, %Y")
+    return f"{dt.strftime('%B')} {dt.day}, {dt.year}"
+
+
+def get_existing_keys(client: AirtableClient, table_id: str) -> set[tuple[str, str]]:
+    """Return {(episode_str, title_str)} for all records already in *table_id*."""
+    records = list_all_records(client, table_id)
+    keys: set[tuple[str, str]] = set()
+    for rec in records:
+        fields = rec.get("fields")
+        if not isinstance(fields, dict):
+            continue
+        ep = str(fields.get("Episode #", "")).strip()
+        title = str(fields.get("Recording Title", "")).strip()
+        if ep and title:
+            keys.add((ep, title))
+    return keys
+
+
+# ---------------------------------------------------------------------------
+# CSV → AirTable field mapping
+# ---------------------------------------------------------------------------
+
+
+def build_fields(row: list[str]) -> dict[str, object]:
+    """Build the AirTable fields dict from a CSV row (positional columns)."""
+    episode_num = row[COL_EPISODE].strip()
+    track_num = row[COL_TRACK].strip()
+    song_title = row[COL_TITLE].strip()
+    raw_date = row[COL_DATE].strip()
+    guest = row[COL_GUEST].strip() if len(row) > COL_GUEST else ""
+
+    long_date = format_long_date(raw_date)
+    album_title = f"{song_title} (Live On The Pat Boone Chevy Showroom, {long_date})"
+
+    title_version = f"Live On The Pat Boone Chevy Showroom, {long_date}"
+
+    fields: dict[str, object] = {
+        "Recording Title": song_title,
+        "Episode #": episode_num,
+        "Date First Aired": parse_iso_date(raw_date),
+        "Album Release Title": album_title,
+        "Title Version": title_version,
+        "Notes": f"Track #{track_num}",
+    }
+    if guest:
+        fields["Featured Artist"] = [a.strip() for a in guest.split(",") if a.strip()]
+    return fields
+
+
+def main(
+    csv_path: Path = typer.Option(DEFAULT_CHEVY_CSV_PATH, "--csv", help="Path to song_index.csv"),
+    apply: bool = typer.Option(False, "--apply", help="Apply the live Airtable import."),
+    episodes: str | None = typer.Option(None, "--episodes", help="Comma-separated episode numbers to import (e.g. '60' or '60,61,62'). Defaults to all episodes ≥60."),
+) -> None:
+    """Import Chevy Showroom songs from CSV into Airtable, skipping duplicates."""
+
+    client = AirtableClient(token=require_token(), base_id=BASE_ID)
+
+    # Parse episode filter
+    episode_filter = parse_episode_filter(episodes)
+    if episode_filter is not None:
+        typer.echo(f"Filtering to episodes: {sorted(episode_filter)}", err=True)
+    else:
+        typer.echo(f"Importing all episodes ≥{DEFAULT_MIN_CHEVY_EPISODE}.", err=True)
+
+    # Fetch existing records for duplicate detection
+    typer.echo("Fetching existing records from AirTable…", err=True)
+    existing_keys = get_existing_keys(client, CHEVY_TABLE_ID)
+    typer.echo(f"  {len(existing_keys)} existing records found.", err=True)
+
+    # Parse CSV and build import list
+    rows_to_import: list[dict[str, object]] = []
+    skipped_episode = 0
+    skipped_blank = 0
+    skipped_duplicate = 0
+
+    with csv_path.open(newline="", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        next(reader)  # skip header row
+        for row in reader:
+            if len(row) < 4:
+                continue
+
+            episode_str = row[COL_EPISODE].strip()
+            song_title = row[COL_TITLE].strip()
+
+            # Skip missing/non-numeric episode numbers
+            if not episode_str:
+                skipped_blank += 1
+                continue
+            try:
+                episode_num = int(episode_str)
+            except ValueError:
+                skipped_blank += 1
+                continue
+
+            # Filter by selected episodes or default lower bound
+            if episode_filter is not None:
+                if episode_num not in episode_filter:
+                    skipped_episode += 1
+                    continue
+            elif episode_num < DEFAULT_MIN_CHEVY_EPISODE:
+                skipped_episode += 1
+                continue
+
+            # Skip rows with no song title
+            if not song_title:
+                skipped_blank += 1
+                continue
+
+            # Skip duplicates already in AirTable
+            if (episode_str, song_title) in existing_keys:
+                skipped_duplicate += 1
+                continue
+
+            rows_to_import.append(build_fields(row))
+
+    typer.echo(
+        f"  Skipped {skipped_episode} rows (episodes ≤59), "
+        f"{skipped_blank} blank, {skipped_duplicate} duplicates.",
+        err=True,
+    )
+    typer.echo(f"  {len(rows_to_import)} records to import.", err=True)
+
+    if not rows_to_import:
+        typer.echo("Nothing to import.", err=True)
+        return
+
+    if not apply:
+        emit_json(rows_to_import)
+        return
+
+    # Batch-create in groups of 10 (AirTable limit per request)
+    created = 0
+    for i in range(0, len(rows_to_import), 10):
+        batch = rows_to_import[i : i + 10]
+        result = client.create_records(CHEVY_TABLE_ID, batch, typecast=True)
+        n = len(result.get("records", []))  # type: ignore[arg-type]
+        created += n
+        typer.echo(f"  Created {created}/{len(rows_to_import)}…", err=True)
+
+    typer.echo(f"Done. {created} records created.", err=True)

--- a/src/atp/chevy_link_releases.py
+++ b/src/atp/chevy_link_releases.py
@@ -1,0 +1,245 @@
+"""Create Releases and Recordings for unlinked Chevy Showroom Dist Mgmt rows.
+
+Each unlinked Chevy row gets one Release and one Recording wired up via four
+phases that mirror AirTable's bidirectional link requirements:
+
+  Phase 1 — Create Release (links Release → Chevy; Chevy.Release auto-populates)
+  Phase 2 — Create Recording (links Recording → Release via Original Release)
+  Phase 3 — Patch Release with Recordings link
+  Phase 4 — Patch Chevy row with Recordings link
+
+Idempotent: rows that already have a Release linked are skipped.
+
+Usage:
+    uv run python scripts/link_chevy_releases.py --dry-run
+    uv run python scripts/link_chevy_releases.py --episodes 60
+    uv run python scripts/link_chevy_releases.py --episodes 60,61,62
+    uv run python scripts/link_chevy_releases.py
+"""
+from __future__ import annotations
+
+import typer
+
+from .api import AirtableClient
+from .common import emit_json, list_all_records, parse_episode_filter, require_token
+from .config import BASE_ID, CHEVY_TABLE_ID, DEFAULT_BATCH_SIZE, RECORDINGS_TABLE_ID, RELEASES_TABLE_ID
+
+
+def fetch_unlinked_chevy_rows(
+    client: AirtableClient,
+    episode_filter: set[int] | None,
+) -> list[dict[str, object]]:
+    """Return Chevy rows that have no Release link yet."""
+    all_records = list_all_records(client, CHEVY_TABLE_ID)
+    unlinked = []
+    for rec in all_records:
+        fields = rec.get("fields")
+        if not isinstance(fields, dict):
+            continue
+        # Skip rows that already have a Release linked
+        if fields.get("Release"):
+            continue
+        # Apply optional episode filter
+        if episode_filter is not None:
+            ep_str = str(fields.get("Episode #", "")).strip()
+            try:
+                ep_num = int(ep_str)
+            except ValueError:
+                continue
+            if ep_num not in episode_filter:
+                continue
+        unlinked.append(rec)
+    return unlinked
+
+
+def build_pending(records: list[dict[str, object]]) -> list[dict[str, object]]:
+    """Map raw AirTable records to a flat list of pending rows.
+
+    Each entry contains the Chevy record ID, song title, album title, and
+    episode number. The release_id and recording_id slots start empty and are
+    filled in by the phase functions.
+
+    Rows missing Album Release Title or Recording Title are skipped.
+    """
+    pending = []
+    for rec in records:
+        fields = rec.get("fields")
+        if not isinstance(fields, dict):
+            continue
+        chevy_id = str(rec.get("id", "")).strip()
+        song_title = str(fields.get("Recording Title", "")).strip()
+        album_title = str(fields.get("Album Release Title", "")).strip()
+        episode = str(fields.get("Episode #", "")).strip()
+        if not chevy_id or not song_title or not album_title:
+            continue
+        pending.append({
+            "chevy_id": chevy_id,
+            "song_title": song_title,
+            "album_title": album_title,
+            "episode": episode,
+            "release_id": "",
+            "recording_id": "",
+        })
+    return pending
+
+
+def _check_response(result: dict[str, object], phase: str) -> None:
+    """Raise a clear error if AirTable returned an error payload."""
+    if "error" in result:
+        err = result["error"]
+        raise typer.Exit(
+            typer.secho(
+                f"  AirTable error in {phase}: {err}",
+                fg=typer.colors.RED,
+                err=True,
+            )
+            or 1
+        )
+    if "records" not in result:
+        raise typer.Exit(
+            typer.secho(
+                f"  Unexpected response in {phase} (no 'records' key): {result}",
+                fg=typer.colors.RED,
+                err=True,
+            )
+            or 1
+        )
+
+
+def phase1_create_releases(
+    client: AirtableClient,
+    pending: list[dict[str, object]],
+) -> None:
+    """Create one Release per pending row; mutates each row with its release_id.
+
+    Setting Releases.Chevy Showroom Dist Mgmt causes AirTable to auto-populate
+    the reverse ChesvyShowroom.Release field for free.
+    """
+    for i in range(0, len(pending), DEFAULT_BATCH_SIZE):
+        batch = pending[i : i + DEFAULT_BATCH_SIZE]
+        fields_list = [
+            {
+                "Release Title": row["album_title"],
+                "Chevy Showroom Dist Mgmt": [row["chevy_id"]],
+            }
+            for row in batch
+        ]
+        result = client.create_records(RELEASES_TABLE_ID, fields_list)
+        _check_response(result, "Phase 1 (create releases)")
+        created = result["records"]
+        for j, rec in enumerate(created):  # type: ignore[union-attr]
+            batch[j]["release_id"] = rec["id"]  # type: ignore[index]
+        typer.echo(
+            f"  Phase 1: created {len(created)}/{len(batch)} releases"
+            f" (total {i + len(created)}/{len(pending)})",
+            err=True,
+        )
+
+
+def phase2_create_recordings(
+    client: AirtableClient,
+    pending: list[dict[str, object]],
+) -> None:
+    """Create one Recording per pending row; mutates each row with its recording_id."""
+    for i in range(0, len(pending), DEFAULT_BATCH_SIZE):
+        batch = pending[i : i + DEFAULT_BATCH_SIZE]
+        fields_list = [
+            {
+                "Title of Recording": row["song_title"],
+                "Original Release": [row["release_id"]],
+            }
+            for row in batch
+        ]
+        result = client.create_records(RECORDINGS_TABLE_ID, fields_list)
+        _check_response(result, "Phase 2 (create recordings)")
+        created = result["records"]
+        for j, rec in enumerate(created):  # type: ignore[union-attr]
+            batch[j]["recording_id"] = rec["id"]  # type: ignore[index]
+        typer.echo(
+            f"  Phase 2: created {len(created)}/{len(batch)} recordings"
+            f" (total {i + len(created)}/{len(pending)})",
+            err=True,
+        )
+
+
+def phase3_update_releases(
+    client: AirtableClient,
+    pending: list[dict[str, object]],
+) -> None:
+    """Patch each Release with its Recordings link."""
+    for i in range(0, len(pending), DEFAULT_BATCH_SIZE):
+        batch = pending[i : i + DEFAULT_BATCH_SIZE]
+        records = [
+            {"id": row["release_id"], "fields": {"Recordings": [row["recording_id"]]}}
+            for row in batch
+        ]
+        result = client.update_records(RELEASES_TABLE_ID, records)
+        _check_response(result, "Phase 3 (update releases)")
+        updated = result["records"]
+        typer.echo(
+            f"  Phase 3: updated {len(updated)}/{len(batch)} releases"
+            f" (total {i + len(updated)}/{len(pending)})",
+            err=True,
+        )
+
+
+def phase4_update_chevy(
+    client: AirtableClient,
+    pending: list[dict[str, object]],
+) -> None:
+    """Patch each Chevy row with its Recordings link."""
+    for i in range(0, len(pending), DEFAULT_BATCH_SIZE):
+        batch = pending[i : i + DEFAULT_BATCH_SIZE]
+        records = [
+            {"id": row["chevy_id"], "fields": {"Recordings": [row["recording_id"]]}}
+            for row in batch
+        ]
+        result = client.update_records(CHEVY_TABLE_ID, records)
+        _check_response(result, "Phase 4 (update Chevy rows)")
+        updated = result["records"]
+        typer.echo(
+            f"  Phase 4: updated {len(updated)}/{len(batch)} Chevy rows"
+            f" (total {i + len(updated)}/{len(pending)})",
+            err=True,
+        )
+
+
+def main(
+    apply: bool = typer.Option(False, "--apply", help="Apply the live Airtable writes."),
+    episodes: str | None = typer.Option(
+        None,
+        "--episodes",
+        help="Comma-separated episode numbers (e.g. '60' or '60,61,62'). Default: all unlinked rows.",
+    ),
+) -> None:
+    """Create Releases + Recordings for unlinked Chevy Showroom Dist Mgmt rows."""
+    client = AirtableClient(token=require_token(), base_id=BASE_ID)
+    episode_filter = parse_episode_filter(episodes)
+    if episode_filter is not None:
+        typer.echo(f"Filtering to episodes: {sorted(episode_filter)}", err=True)
+    else:
+        typer.echo("Processing all unlinked rows.", err=True)
+
+    typer.echo("Fetching unlinked Chevy rows…", err=True)
+    unlinked = fetch_unlinked_chevy_rows(client, episode_filter)
+    typer.echo(f"  {len(unlinked)} unlinked rows found.", err=True)
+
+    pending = build_pending(unlinked)
+    skipped = len(unlinked) - len(pending)
+    if skipped:
+        typer.echo(f"  {skipped} rows skipped (missing required fields).", err=True)
+
+    if not pending:
+        typer.echo("0 rows need linking.", err=True)
+        return
+
+    if not apply:
+        emit_json(pending)
+        return
+
+    typer.echo(f"Processing {len(pending)} rows in 4 phases…", err=True)
+    phase1_create_releases(client, pending)
+    phase2_create_recordings(client, pending)
+    phase3_update_releases(client, pending)
+    phase4_update_chevy(client, pending)
+    typer.echo(f"Done. {len(pending)} rows linked.", err=True)

--- a/src/atp/chevy_patch_featured_artists.py
+++ b/src/atp/chevy_patch_featured_artists.py
@@ -1,0 +1,263 @@
+"""Resolve Chevy Showroom featured artist names to Artist record IDs and patch
+linked Releases and Recordings.
+
+Chevy rows store guest artists as text names in a Multiple select field
+("Featured Artist"). The linked Releases and Recordings have Link-to-record
+fields that need real Artist record IDs. This script bridges the gap.
+
+Traversal:
+  Chevy rows → Release field     → Releases   → patch "Featured Artist(s)"
+  Chevy rows → Recordings field  → Recordings → patch "Featured Artist"
+
+Idempotent: existing artist IDs are read and merged; only new IDs trigger a
+PATCH call.
+
+Usage:
+    uv run python scripts/patch_chevy_featured_artists.py --dry-run
+    uv run python scripts/patch_chevy_featured_artists.py --episodes 60,61,62
+    uv run python scripts/patch_chevy_featured_artists.py   # all rows
+"""
+from __future__ import annotations
+
+import typer
+
+from .api import AirtableClient
+from .common import emit_json, list_all_records, parse_episode_filter, require_token
+from .config import (
+    ARTISTS_TABLE_ID,
+    BASE_ID,
+    CHEVY_TABLE_ID,
+    DEFAULT_BATCH_SIZE,
+    RECORDINGS_TABLE_ID,
+    RELEASES_TABLE_ID,
+)
+
+# Field names used in PATCH payloads
+RELEASES_FA_FIELD = "Featured Artist(s)"
+RECORDINGS_FA_FIELD = "Featured Artist"
+
+def build_artist_name_map(client: AirtableClient) -> dict[str, str]:
+    """Return lowercased name → record_id for every Artist record.
+
+    Warns on name collisions (keeps first occurrence).
+    """
+    typer.echo("Fetching all Artist records to build name map…", err=True)
+    records = list_all_records(client, ARTISTS_TABLE_ID)
+    typer.echo(f"  {len(records)} Artist records found.", err=True)
+
+    name_map: dict[str, str] = {}
+    for rec in records:
+        record_id = rec.get("id")
+        fields = rec.get("fields")
+        if not isinstance(record_id, str) or not isinstance(fields, dict):
+            continue
+        name = fields.get("Name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        key = name.strip().lower()
+        if key in name_map:
+            typer.secho(
+                f"  WARNING: duplicate artist name {name!r} — keeping {name_map[key]}, ignoring {record_id}",
+                fg=typer.colors.YELLOW,
+                err=True,
+            )
+        else:
+            name_map[key] = record_id
+    return name_map
+
+
+def resolve_artist_names(
+    names: list[str],
+    name_map: dict[str, str],
+    context: str,
+) -> list[str]:
+    """Resolve a list of text names to Artist record IDs.
+
+    Warns for each unresolved name and returns only the successfully resolved IDs.
+    """
+    resolved: list[str] = []
+    for name in names:
+        key = name.strip().lower()
+        record_id = name_map.get(key)
+        if record_id is None:
+            typer.secho(
+                f"  WARNING: unresolved artist name {name!r} in {context} — skipping",
+                fg=typer.colors.YELLOW,
+                err=True,
+            )
+        else:
+            resolved.append(record_id)
+    return resolved
+
+
+def accumulate_patches(
+    chevy_records: list[dict[str, object]],
+    episode_filter: set[int] | None,
+    name_map: dict[str, str],
+) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    """Walk qualifying Chevy rows and accumulate artist IDs per Release/Recording.
+
+    Returns (release_patches, recording_patches) where each is a dict from
+    record_id → set of artist record IDs that should appear in that record.
+    """
+    release_patches: dict[str, set[str]] = {}
+    recording_patches: dict[str, set[str]] = {}
+
+    for rec in chevy_records:
+        fields = rec.get("fields")
+        if not isinstance(fields, dict):
+            continue
+
+        if episode_filter is not None:
+            ep_str = str(fields.get("Episode #", "")).strip()
+            try:
+                ep_num = int(ep_str)
+            except ValueError:
+                continue
+            if ep_num not in episode_filter:
+                continue
+
+        raw_artists = fields.get("Featured Artist")
+        if not raw_artists:
+            continue
+        if not isinstance(raw_artists, list):
+            continue
+
+        context = f"Chevy row {rec.get('id', '?')} (ep {fields.get('Episode #', '?')})"
+        artist_ids = resolve_artist_names(raw_artists, name_map, context)  # type: ignore[arg-type]
+        if not artist_ids:
+            continue
+
+        for release_id in fields.get("Release", []):  # type: ignore[union-attr]
+            if isinstance(release_id, str):
+                release_patches.setdefault(release_id, set()).update(artist_ids)
+
+        for recording_id in fields.get("Recordings", []):  # type: ignore[union-attr]
+            if isinstance(recording_id, str):
+                recording_patches.setdefault(recording_id, set()).update(artist_ids)
+
+    return release_patches, recording_patches
+
+
+def build_patch_list(
+    client: AirtableClient,
+    table_id: str,
+    patches: dict[str, set[str]],
+    fa_field: str,
+    table_label: str,
+) -> list[dict[str, object]]:
+    """For each record, fetch existing Featured Artist IDs and merge with new ones.
+
+    Returns only records where the merged set is larger than the existing set
+    (i.e. there are genuinely new IDs to add).
+    """
+    result: list[dict[str, object]] = []
+    for record_id, new_ids in patches.items():
+        rec = client.retrieve_record(table_id, record_id)
+        fields = rec.get("fields")
+        if not isinstance(fields, dict):
+            typer.secho(
+                f"  WARNING: could not read fields for {table_label}/{record_id}",
+                fg=typer.colors.YELLOW,
+                err=True,
+            )
+            continue
+
+        existing: list[str] = fields.get(fa_field, [])  # type: ignore[assignment]
+        if not isinstance(existing, list):
+            existing = []
+
+        existing_set = set(existing)
+        merged = existing_set | new_ids
+
+        if merged == existing_set:
+            # Nothing to add
+            continue
+
+        result.append({"id": record_id, "fields": {fa_field: sorted(merged)}})
+    return result
+
+
+def apply_patches(
+    client: AirtableClient,
+    table_id: str,
+    patches: list[dict[str, object]],
+    table_label: str,
+) -> None:
+    """Batch-PATCH records in groups of BATCH_SIZE."""
+    total = len(patches)
+    updated = 0
+    for i in range(0, total, DEFAULT_BATCH_SIZE):
+        batch = patches[i : i + DEFAULT_BATCH_SIZE]
+        result = client.update_records(table_id, batch)
+        if "error" in result:
+            typer.secho(
+                f"  AirTable error patching {table_label}: {result['error']}",
+                fg=typer.colors.RED,
+                err=True,
+            )
+            raise typer.Exit(1)
+        n = len(result.get("records", []))  # type: ignore[arg-type]
+        updated += n
+        typer.echo(f"  {table_label}: patched {updated}/{total}", err=True)
+
+
+def main(
+    apply: bool = typer.Option(False, "--apply", help="Apply the live Airtable patches."),
+    episodes: str | None = typer.Option(
+        None,
+        "--episodes",
+        help="Comma-separated episode numbers to process (e.g. '60' or '60,61'). Default: all rows.",
+    ),
+) -> None:
+    """Patch Featured Artist links on Releases and Recordings linked from Chevy rows."""
+    client = AirtableClient(token=require_token(), base_id=BASE_ID)
+    episode_filter = parse_episode_filter(episodes)
+    if episode_filter is not None:
+        typer.echo(f"Filtering to episodes: {sorted(episode_filter)}", err=True)
+
+    # Step 1 — build name map
+    name_map = build_artist_name_map(client)
+
+    # Step 2 — fetch Chevy rows
+    typer.echo("Fetching all Chevy Showroom Dist Mgmt rows…", err=True)
+    chevy_records = list_all_records(client, CHEVY_TABLE_ID)
+    typer.echo(f"  {len(chevy_records)} rows found.", err=True)
+
+    # Step 3 — accumulate patches
+    release_acc, recording_acc = accumulate_patches(chevy_records, episode_filter, name_map)
+    typer.echo(
+        f"  {len(release_acc)} Releases and {len(recording_acc)} Recordings have featured artists to check.",
+        err=True,
+    )
+
+    # Step 4 — idempotency check: build final patch lists
+    typer.echo("Checking Releases for missing Featured Artist links…", err=True)
+    release_patches = build_patch_list(client, RELEASES_TABLE_ID, release_acc, RELEASES_FA_FIELD, "Releases")
+    typer.echo(f"  {len(release_patches)} Releases need patching.", err=True)
+
+    typer.echo("Checking Recordings for missing Featured Artist links…", err=True)
+    recording_patches = build_patch_list(client, RECORDINGS_TABLE_ID, recording_acc, RECORDINGS_FA_FIELD, "Recordings")
+    typer.echo(f"  {len(recording_patches)} Recordings need patching.", err=True)
+
+    if not release_patches and not recording_patches:
+        typer.echo("All records already have correct Featured Artist links. Nothing to do.", err=True)
+        return
+
+    if not apply:
+        emit_json({"releases": release_patches, "recordings": recording_patches})
+        return
+
+    # Step 5 — apply patches
+    if release_patches:
+        typer.echo(f"Patching {len(release_patches)} Releases…", err=True)
+        apply_patches(client, RELEASES_TABLE_ID, release_patches, "Releases")
+
+    if recording_patches:
+        typer.echo(f"Patching {len(recording_patches)} Recordings…", err=True)
+        apply_patches(client, RECORDINGS_TABLE_ID, recording_patches, "Recordings")
+
+    typer.echo(
+        f"Done. {len(release_patches)} Releases and {len(recording_patches)} Recordings updated.",
+        err=True,
+    )

--- a/src/atp/chevy_patch_primary_artist.py
+++ b/src/atp/chevy_patch_primary_artist.py
@@ -1,0 +1,191 @@
+"""Set Primary Artist = Pat Boone on all Releases and Recordings linked from
+Chevy Showroom Dist Mgmt rows.
+
+Pat Boone's AirTable artist record ID: recLWgt9qnlgDkkAo
+
+Traversal:
+  Chevy rows → Release field  → Releases  → patch Primary Artist if missing
+  Chevy rows → Recordings field → Recordings → patch Primary Artist if missing
+
+Idempotent: records that already have Pat Boone as Primary Artist are skipped.
+Records that already have a *different* Primary Artist are logged as warnings and
+still patched (the user's intent is that every Chevy Release/Recording belongs
+to Pat Boone).
+
+Usage:
+    uv run python scripts/patch_chevy_primary_artist.py --dry-run
+    uv run python scripts/patch_chevy_primary_artist.py --episodes 60
+    uv run python scripts/patch_chevy_primary_artist.py
+"""
+from __future__ import annotations
+
+import typer
+
+from .api import AirtableClient
+from .common import emit_json, list_all_records, parse_episode_filter, require_token
+from .config import (
+    BASE_ID,
+    CHEVY_TABLE_ID,
+    DEFAULT_BATCH_SIZE,
+    PAT_BOONE_RECORD_ID,
+    RECORDINGS_TABLE_ID,
+    RELEASES_TABLE_ID,
+)
+
+
+def collect_linked_ids(
+    chevy_records: list[dict[str, object]],
+    episode_filter: set[int] | None,
+) -> tuple[list[str], list[str]]:
+    """Return (release_ids, recording_ids) from Chevy rows, respecting episode filter.
+
+    Deduplicates IDs while preserving first-seen order.
+    """
+    seen_releases: set[str] = set()
+    seen_recordings: set[str] = set()
+    release_ids: list[str] = []
+    recording_ids: list[str] = []
+
+    for rec in chevy_records:
+        fields = rec.get("fields")
+        if not isinstance(fields, dict):
+            continue
+
+        if episode_filter is not None:
+            ep_str = str(fields.get("Episode #", "")).strip()
+            try:
+                ep_num = int(ep_str)
+            except ValueError:
+                continue
+            if ep_num not in episode_filter:
+                continue
+
+        for rid in fields.get("Release", []):  # type: ignore[union-attr]
+            if isinstance(rid, str) and rid not in seen_releases:
+                seen_releases.add(rid)
+                release_ids.append(rid)
+
+        for rid in fields.get("Recordings", []):  # type: ignore[union-attr]
+            if isinstance(rid, str) and rid not in seen_recordings:
+                seen_recordings.add(rid)
+                recording_ids.append(rid)
+
+    return release_ids, recording_ids
+
+
+def find_missing(
+    client: AirtableClient,
+    table_id: str,
+    record_ids: list[str],
+    table_label: str,
+) -> list[dict[str, object]]:
+    """Return patch dicts for records whose Primary Artist != Pat Boone.
+
+    Logs skips (already correct) and warnings (overwriting a different artist).
+    """
+    patches: list[dict[str, object]] = []
+
+    for record_id in record_ids:
+        rec = client.retrieve_record(table_id, record_id)
+        fields = rec.get("fields")
+        if not isinstance(fields, dict):
+            typer.secho(
+                f"  WARNING: could not read fields for {table_label}/{record_id}",
+                fg=typer.colors.YELLOW,
+                err=True,
+            )
+            continue
+
+        current: list[str] = fields.get("Primary Artist", [])  # type: ignore[assignment]
+        if isinstance(current, list) and PAT_BOONE_RECORD_ID in current:
+            # Already correct — skip
+            continue
+
+        if current:
+            typer.secho(
+                f"  OVERWRITING Primary Artist on {table_label}/{record_id}"
+                f" (was: {current})",
+                fg=typer.colors.YELLOW,
+                err=True,
+            )
+        patches.append({"id": record_id, "fields": {"Primary Artist": [PAT_BOONE_RECORD_ID]}})
+
+    return patches
+
+
+def apply_patches(
+    client: AirtableClient,
+    table_id: str,
+    patches: list[dict[str, object]],
+    table_label: str,
+) -> None:
+    """Batch-PATCH records in groups of BATCH_SIZE."""
+    total = len(patches)
+    updated = 0
+    for i in range(0, total, DEFAULT_BATCH_SIZE):
+        batch = patches[i : i + DEFAULT_BATCH_SIZE]
+        result = client.update_records(table_id, batch)
+        if "error" in result:
+            typer.secho(
+                f"  AirTable error patching {table_label}: {result['error']}",
+                fg=typer.colors.RED,
+                err=True,
+            )
+            raise typer.Exit(1)
+        n = len(result.get("records", []))  # type: ignore[arg-type]
+        updated += n
+        typer.echo(
+            f"  {table_label}: patched {updated}/{total}",
+            err=True,
+        )
+
+
+def main(
+    apply: bool = typer.Option(False, "--apply", help="Apply the live Airtable patches."),
+    episodes: str | None = typer.Option(
+        None,
+        "--episodes",
+        help="Comma-separated episode numbers to process (e.g. '60' or '60,61'). Default: all rows.",
+    ),
+) -> None:
+    """Ensure Pat Boone is Primary Artist on all Chevy-linked Releases and Recordings."""
+    client = AirtableClient(token=require_token(), base_id=BASE_ID)
+    episode_filter = parse_episode_filter(episodes)
+    if episode_filter is not None:
+        typer.echo(f"Filtering to episodes: {sorted(episode_filter)}", err=True)
+
+    typer.echo("Fetching all Chevy Showroom Dist Mgmt rows…", err=True)
+    chevy_records = list_all_records(client, CHEVY_TABLE_ID)
+    typer.echo(f"  {len(chevy_records)} rows found.", err=True)
+
+    release_ids, recording_ids = collect_linked_ids(chevy_records, episode_filter)
+    typer.echo(f"  {len(release_ids)} linked Releases, {len(recording_ids)} linked Recordings.", err=True)
+
+    typer.echo("Checking Releases for missing Primary Artist…", err=True)
+    release_patches = find_missing(client, RELEASES_TABLE_ID, release_ids, "Releases")
+    typer.echo(f"  {len(release_patches)} Releases need patching.", err=True)
+
+    typer.echo("Checking Recordings for missing Primary Artist…", err=True)
+    recording_patches = find_missing(client, RECORDINGS_TABLE_ID, recording_ids, "Recordings")
+    typer.echo(f"  {len(recording_patches)} Recordings need patching.", err=True)
+
+    if not release_patches and not recording_patches:
+        typer.echo("All records already have Pat Boone as Primary Artist. Nothing to do.", err=True)
+        return
+
+    if not apply:
+        emit_json({"releases": release_patches, "recordings": recording_patches})
+        return
+
+    if release_patches:
+        typer.echo(f"Patching {len(release_patches)} Releases…", err=True)
+        apply_patches(client, RELEASES_TABLE_ID, release_patches, "Releases")
+
+    if recording_patches:
+        typer.echo(f"Patching {len(recording_patches)} Recordings…", err=True)
+        apply_patches(client, RECORDINGS_TABLE_ID, recording_patches, "Recordings")
+
+    typer.echo(
+        f"Done. {len(release_patches)} Releases and {len(recording_patches)} Recordings updated.",
+        err=True,
+    )

--- a/src/atp/common.py
+++ b/src/atp/common.py
@@ -1,0 +1,85 @@
+"""Shared helpers for CLI commands."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import typer
+from dotenv import load_dotenv
+
+from .api import AirtableClient
+from .config import ENV_TOKEN_NAME
+
+
+def find_project_root() -> Path:
+    """Walk up from this file to the directory containing pyproject.toml."""
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise FileNotFoundError("Could not find project root (no pyproject.toml found)")
+
+
+def load_project_env() -> None:
+    """Load the repo .env when it exists."""
+    env_path = find_project_root() / ".env"
+    if env_path.exists():
+        load_dotenv(env_path)
+
+
+def resolve_token() -> str:
+    load_project_env()
+    return os.getenv(ENV_TOKEN_NAME, "")
+
+
+def require_token() -> str:
+    token = resolve_token()
+    if not token:
+        typer.echo(f"{ENV_TOKEN_NAME} not set.", err=True)
+        raise typer.Exit(1)
+    return token
+
+
+def parse_episode_filter(value: str | None) -> set[int] | None:
+    """Parse a comma-separated episode filter into a set of ints."""
+    if value is None:
+        return None
+    parts = [part.strip() for part in value.split(",") if part.strip()]
+    result: set[int] = set()
+    for part in parts:
+        try:
+            result.add(int(part))
+        except ValueError:
+            typer.echo(f"Invalid episode number: {part!r}", err=True)
+            raise typer.Exit(1)
+    return result
+
+
+def list_all_records(client: AirtableClient, table_id: str) -> list[dict[str, Any]]:
+    """Fetch every record from a table by following offset pagination."""
+    all_records: list[dict[str, Any]] = []
+    offset = ""
+    while True:
+        result = client.list_records(table_id, offset=offset)
+        records = result.get("records")
+        if isinstance(records, list):
+            all_records.extend(records)
+        next_offset = result.get("offset")
+        if not next_offset:
+            break
+        offset = str(next_offset)
+    return all_records
+
+
+def parse_field_pairs(field_pairs: list[str]) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for pair in field_pairs:
+        key, _, value = pair.partition("=")
+        if key:
+            fields[key.strip()] = value
+    return fields
+
+
+def emit_json(data: Any) -> None:
+    typer.echo(json.dumps(data, indent=2))

--- a/src/atp/config.py
+++ b/src/atp/config.py
@@ -1,0 +1,29 @@
+"""Shared project configuration for AirTable PBGL."""
+from __future__ import annotations
+
+from pathlib import Path
+
+APP_NAME = "AirTable PBGL"
+CLI_NAME = "atp"
+CLI_EXPANSION = "AirTable PBGL"
+ENV_TOKEN_NAME = "AIRTABLE_API_TOKEN"
+BASE_ID = "appEurfA8kXQE3slK"
+
+CHEVY_TABLE_ID = "tblRqFtQrPCNB1fwT"
+RELEASES_TABLE_ID = "tbl7rjVKUd5faZ7fV"
+RECORDINGS_TABLE_ID = "tblESvQQmOBbEXAH0"
+ARTISTS_TABLE_ID = "tbla7zxpHm76x0Aj9"
+PAT_BOONE_RECORD_ID = "recLWgt9qnlgDkkAo"
+
+DEFAULT_BATCH_SIZE = 10
+DEFAULT_EXPAND_DEPTH = 5
+DEFAULT_MIN_CHEVY_EPISODE = 60
+
+DEFAULT_CHEVY_CSV_PATH = Path(
+    "/Users/daniellyons/Library/CloudStorage/Box-Box"
+    "/The Gold Label/The Pat Boone Chevy Showroom"
+    "/Episode Info/song_index.csv"
+)
+
+DOCS_DIRNAME = "DOCS"
+AIRTABLE_DOCS_DIRNAME = "AIRTABLE_API"

--- a/src/atp/expand.py
+++ b/src/atp/expand.py
@@ -1,0 +1,234 @@
+"""Recursive linked-record expansion for AirTable API responses."""
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from .api import AirtableClient
+    from .md_parser import TableInfo
+
+# table_id -> {field_name -> target_table_id}
+LinkInfo = dict[str, dict[str, str]]
+
+_LINK_PATTERN = re.compile(r"Array of linked records IDs from the (.+?) table\.")
+_LINK_FIELD_TYPE = "Link to another record"
+
+_REC_ID_RE = re.compile(r"^rec[A-Za-z0-9]{14}$")
+
+
+def _is_raw_id_list(value: Any) -> bool:
+    return (
+        isinstance(value, list)
+        and bool(value)
+        and all(isinstance(v, str) and _REC_ID_RE.match(v) for v in value)
+    )
+
+
+@dataclass
+class SpineEntry:
+    """Traversal policy for one table in the ownership spine.
+
+    Fields in `follow` (or matching `follow_re`) are recursively expanded.
+    Fields in `name_only` (or matching `name_only_re`) are fetched as {id, _name}.
+    All other linked fields are stripped from the output.
+    """
+
+    follow: frozenset[str] = field(default_factory=frozenset)
+    name_only: frozenset[str] = field(default_factory=frozenset)
+    follow_re: re.Pattern[str] | None = None
+    name_only_re: re.Pattern[str] | None = None
+
+    def classify(self, field_name: str) -> Literal["follow", "name_only", "skip"]:
+        if field_name in self.follow or (self.follow_re and self.follow_re.match(field_name)):
+            return "follow"
+        if field_name in self.name_only or (self.name_only_re and self.name_only_re.match(field_name)):
+            return "name_only"
+        return "skip"
+
+
+# Hardcoded traversal policy keyed by table ID.
+# Tables not present here get an implicit empty SpineEntry — all linked fields stripped.
+_SPINE: dict[str, SpineEntry] = {
+    "tbl7rjVKUd5faZ7fV": SpineEntry(  # Releases
+        follow=frozenset({"Recordings"}),
+        name_only=frozenset({
+            "Primary Artist",
+            "Featured Artist(s)",
+            "Original release label",
+            "Current release label",
+        }),
+    ),
+    "tblESvQQmOBbEXAH0": SpineEntry(  # Recordings
+        follow=frozenset({"Compositions", "Compositions 2", "Compositions 3"}),
+        name_only=frozenset({
+            "Primary Artist",
+            "Featured Artist",
+            "Master Owner 1",
+            "Master Owner 2",
+            "Master Owner 3",
+        }),
+    ),
+    "tblomWINKPjfgAVpo": SpineEntry(  # Compositions
+        follow_re=re.compile(r"^Songwriter [1-9]$"),
+        name_only_re=re.compile(r"^Songwriter [1-9] .*Pub"),
+    ),
+    "tbl2KLh2RIrS5AmSX": SpineEntry(),  # Songwriters — leaf
+    "tbl6TNKQRPfY3hXZ2": SpineEntry(),  # Publishers — leaf
+}
+
+
+@dataclass
+class ExpandConfig:
+    """Pre-computed, traversal-invariant configuration for expand_record."""
+
+    # table_id -> name of the primary (first) field, used for name-only resolution
+    primary_field_map: dict[str, str] = field(default_factory=dict)
+    # (table_id, record_id) -> display name; shared across all recursion branches
+    name_cache: dict[tuple[str, str], str] = field(default_factory=dict)
+
+
+def build_link_info(tables: list[TableInfo]) -> LinkInfo:
+    """Build a map of table_id -> {field_name -> target_table_id} for linked fields."""
+    name_to_id: dict[str, str] = {t["name"]: t["table_id"] for t in tables}
+    link_info: LinkInfo = {}
+
+    for table in tables:
+        tid = table["table_id"]
+        for fld in table["fields"]:
+            if fld["type"] != _LINK_FIELD_TYPE:
+                continue
+            m = _LINK_PATTERN.search(fld["description"])
+            if not m:
+                continue
+            target_name = m.group(1)
+            target_id = name_to_id.get(target_name)
+            if target_id is None:
+                continue
+            link_info.setdefault(tid, {})[fld["name"]] = target_id
+
+    return link_info
+
+
+def build_expand_config(tables: list[TableInfo]) -> ExpandConfig:
+    """Build expansion config from loaded tables.
+
+    Derives a primary-field map (first field per table, used for name resolution).
+    """
+    primary_field_map = {
+        t["table_id"]: t["fields"][0]["name"]
+        for t in tables
+        if t["fields"]
+    }
+    return ExpandConfig(primary_field_map=primary_field_map)
+
+
+def expand_api_response(
+    result: dict[str, Any],
+    table_id: str,
+    tables: list[TableInfo],
+    client: AirtableClient,
+    depth: int,
+    *,
+    on_fetch: Callable[[str, str], None] | None = None,
+) -> dict[str, Any]:
+    """Expand linked records in a raw AirTable API response.
+
+    Handles both list responses ({"records": [...]}) and single-record
+    responses ({"id": ..., "fields": {...}}) by inspecting the result shape.
+    """
+    link_info = build_link_info(tables)
+    config = build_expand_config(tables)
+
+    if "records" in result:
+        records = result.get("records", [])
+        result["records"] = [
+            expand_record(rec, table_id, link_info, client, depth,  # type: ignore[arg-type]
+                          config=config, on_fetch=on_fetch)
+            for rec in records  # type: ignore[union-attr]
+        ]
+        return result
+    else:
+        return expand_record(result, table_id, link_info, client, depth,
+                             config=config, on_fetch=on_fetch)
+
+
+def expand_record(
+    record: dict[str, Any],
+    table_id: str,
+    link_info: LinkInfo,
+    client: AirtableClient,
+    depth: int,
+    *,
+    config: ExpandConfig | None = None,
+    on_fetch: Callable[[str, str], None] | None = None,
+) -> dict[str, Any]:
+    """Recursively expand linked-record fields using the hardcoded ownership spine.
+
+    Args:
+        record: AirTable record dict {"id": ..., "fields": {...}}.
+        table_id: The table this record belongs to.
+        link_info: Built by build_link_info().
+        client: AirtableClient for fetching linked records.
+        depth: Remaining expansion depth; 0 strips all raw ID lists and returns.
+        config: Pre-computed expansion config. Uses empty defaults if omitted.
+        on_fetch: Called just before each HTTP request as on_fetch(table_id, record_id).
+    """
+    _config = config or ExpandConfig()
+
+    if depth == 0:
+        record["fields"] = {
+            k: v for k, v in record.get("fields", {}).items() if not _is_raw_id_list(v)  # type: ignore[union-attr]
+        }
+        return record
+
+    entry = _SPINE.get(table_id, SpineEntry())
+    table_links = link_info.get(table_id, {})
+    fields: dict[str, Any] = record.get("fields", {})  # type: ignore[assignment]
+
+    for field_name, target_table_id in table_links.items():
+        value = fields.get(field_name)
+        if not isinstance(value, list) or not value:
+            continue
+
+        classification = entry.classify(field_name)
+
+        if classification == "skip":
+            del fields[field_name]
+            continue
+
+        expanded: list[dict[str, Any]] = []
+        for linked_id in value:
+            cache_key = (target_table_id, linked_id)
+            if classification == "name_only":
+                if cache_key in _config.name_cache:
+                    expanded.append({"id": linked_id, "_name": _config.name_cache[cache_key]})
+                else:
+                    if on_fetch:
+                        on_fetch(target_table_id, linked_id)
+                    fetched: dict[str, Any] = client.retrieve_record(target_table_id, linked_id)  # type: ignore[assignment]
+                    primary_field = _config.primary_field_map.get(target_table_id)
+                    name_val = fetched.get("fields", {}).get(primary_field) if primary_field else None  # type: ignore[union-attr]
+                    _config.name_cache[cache_key] = name_val  # type: ignore[assignment]
+                    expanded.append({"id": linked_id, "_name": name_val})
+            else:  # "follow"
+                if on_fetch:
+                    on_fetch(target_table_id, linked_id)
+                linked_record: dict[str, Any] = client.retrieve_record(target_table_id, linked_id)  # type: ignore[assignment]
+                expanded.append(
+                    expand_record(
+                        linked_record,
+                        target_table_id,
+                        link_info,
+                        client,
+                        depth - 1,
+                        config=_config,
+                        on_fetch=on_fetch,
+                    )
+                )
+        fields[field_name] = expanded
+
+    record["fields"] = {k: v for k, v in fields.items() if not _is_raw_id_list(v)}
+    return record

--- a/src/atp/main.py
+++ b/src/atp/main.py
@@ -1,0 +1,199 @@
+"""CLI entry point for ATP: AirTable PBGL."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import typer
+
+from .api import AirtableClient
+from .chevy_import_songs import main as chevy_import_songs
+from .chevy_link_releases import main as chevy_link_releases
+from .chevy_patch_featured_artists import main as chevy_patch_featured_artists
+from .chevy_patch_primary_artist import main as chevy_patch_primary_artist
+from .common import emit_json, parse_field_pairs, require_token, resolve_token
+from .config import CLI_EXPANSION, CLI_NAME, DEFAULT_EXPAND_DEPTH
+from .md_parser import TableInfo, find_md_dir, load_tables
+from .schema_parser import parse_html_to_markdown
+
+app = typer.Typer(
+    name=CLI_NAME,
+    help=f"{CLI_NAME} stands for {CLI_EXPANSION}. Default action launches the Textual TUI.",
+    add_completion=False,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+records_app = typer.Typer(help="Generic Airtable record operations.")
+schema_app = typer.Typer(help="Schema and metadata maintenance commands.")
+chevy_app = typer.Typer(help="Chevy Showroom and PBGL-specific automation commands.")
+
+
+def _find_table(table_name: str) -> TableInfo:
+    tables = load_tables(find_md_dir())
+    match = next((table for table in tables if table["name"].lower() == table_name.lower()), None)
+    if match is None:
+        names = ", ".join(table["name"] for table in tables)
+        typer.echo(f"Table not found: {table_name!r}. Available: {names}", err=True)
+        raise typer.Exit(1)
+    return match
+
+
+def _get_client_and_tables(table_name: str) -> tuple[AirtableClient, str, list[TableInfo]]:
+    token = require_token()
+    tables = load_tables(find_md_dir())
+    match = next((table for table in tables if table["name"].lower() == table_name.lower()), None)
+    if match is None:
+        names = ", ".join(table["name"] for table in tables)
+        typer.echo(f"Table not found: {table_name!r}. Available: {names}", err=True)
+        raise typer.Exit(1)
+    client = AirtableClient(token=token, base_id=match["base_id"])
+    return client, match["table_id"] or match["name"], tables
+
+
+def _preview(action: str, table: TableInfo, payload: dict[str, Any]) -> None:
+    emit_json({
+        "action": action,
+        "apply": False,
+        "table": table["name"],
+        "table_id": table["table_id"] or table["name"],
+        "payload": payload,
+    })
+
+
+@app.callback(invoke_without_command=True)
+def default(ctx: typer.Context) -> None:
+    """Launch the TUI when `atp` is run without a subcommand."""
+    if ctx.invoked_subcommand is None:
+        from .app import AirtableTUI
+
+        AirtableTUI(token=resolve_token()).run()
+
+
+@app.command()
+def tui() -> None:
+    """Launch the Textual TUI."""
+    from .app import AirtableTUI
+
+    AirtableTUI(token=resolve_token()).run()
+
+
+@records_app.command("list")
+def list_records(
+    table: str = typer.Argument(..., help="Table name"),
+    filter_formula: str = typer.Option("", "--filter", help="filterByFormula expression"),
+    max_records: int = typer.Option(0, "--max-records", help="Max records to return"),
+    view: str = typer.Option("", "--view", help="View name"),
+    expand: bool = typer.Option(False, "--expand", help="Recursively expand linked records"),
+    depth: int = typer.Option(DEFAULT_EXPAND_DEPTH, "--depth", min=0, help="Max expansion depth"),
+) -> None:
+    """List records from a table."""
+    client, table_id, tables = _get_client_and_tables(table)
+    typer.echo(f"-> GET {table}", err=True)
+    result = client.list_records(table_id, filter_formula=filter_formula, max_records=max_records, view=view)
+    if expand:
+        from .expand import expand_api_response
+
+        table_name_map = {table_info["table_id"]: table_info["name"] for table_info in tables}
+
+        def on_fetch(fetch_table_id: str, record_id: str) -> None:
+            typer.echo(f"  -> GET {table_name_map.get(fetch_table_id, fetch_table_id)} / {record_id}", err=True)
+
+        result = expand_api_response(result, table_id, tables, client, depth, on_fetch=on_fetch)
+    emit_json(result)
+
+
+@records_app.command()
+def retrieve(
+    table: str = typer.Argument(..., help="Table name"),
+    record_id: str = typer.Argument(..., help="Record ID (recXXXXXXXXXXXXXX)"),
+    expand: bool = typer.Option(False, "--expand", help="Recursively expand linked records"),
+    depth: int = typer.Option(DEFAULT_EXPAND_DEPTH, "--depth", min=0, help="Max expansion depth"),
+) -> None:
+    """Retrieve a single record by ID."""
+    client, table_id, tables = _get_client_and_tables(table)
+    typer.echo(f"-> GET {table} / {record_id}", err=True)
+    result = client.retrieve_record(table_id, record_id)
+    if expand:
+        from .expand import expand_api_response
+
+        table_name_map = {table_info["table_id"]: table_info["name"] for table_info in tables}
+
+        def on_fetch(fetch_table_id: str, linked_record_id: str) -> None:
+            typer.echo(f"  -> GET {table_name_map.get(fetch_table_id, fetch_table_id)} / {linked_record_id}", err=True)
+
+        result = expand_api_response(result, table_id, tables, client, depth, on_fetch=on_fetch)
+    emit_json(result)
+
+
+@records_app.command()
+def create(
+    table: str = typer.Argument(..., help="Table name"),
+    field: list[str] = typer.Option([], "--field", help="Field value as 'Name=value' (repeatable)"),
+    apply: bool = typer.Option(False, "--apply", help="Apply the live Airtable write."),
+) -> None:
+    """Create a record. Defaults to preview mode unless `--apply` is passed."""
+    table_info = _find_table(table)
+    fields = parse_field_pairs(field)
+    payload = {"records": [{"fields": fields}]}
+    if not apply:
+        _preview("create", table_info, payload)
+        return
+    client = AirtableClient(token=require_token(), base_id=table_info["base_id"])
+    emit_json(client.create_records(table_info["table_id"] or table_info["name"], [fields]))
+
+
+@records_app.command()
+def update(
+    table: str = typer.Argument(..., help="Table name"),
+    record_id: str = typer.Argument(..., help="Record ID (recXXXXXXXXXXXXXX)"),
+    field: list[str] = typer.Option([], "--field", help="Field value as 'Name=value' (repeatable)"),
+    apply: bool = typer.Option(False, "--apply", help="Apply the live Airtable write."),
+) -> None:
+    """Update a record. Defaults to preview mode unless `--apply` is passed."""
+    table_info = _find_table(table)
+    payload = {"records": [{"id": record_id, "fields": parse_field_pairs(field)}]}
+    if not apply:
+        _preview("update", table_info, payload)
+        return
+    client = AirtableClient(token=require_token(), base_id=table_info["base_id"])
+    emit_json(client.update_records(table_info["table_id"] or table_info["name"], payload["records"]))  # type: ignore[arg-type]
+
+
+@records_app.command()
+def delete(
+    table: str = typer.Argument(..., help="Table name"),
+    record_ids: list[str] = typer.Argument(..., help="One or more record IDs to delete"),
+    apply: bool = typer.Option(False, "--apply", help="Apply the live Airtable delete."),
+) -> None:
+    """Delete one or more records. Defaults to preview mode unless `--apply` is passed."""
+    table_info = _find_table(table)
+    payload = {"records": record_ids}
+    if not apply:
+        _preview("delete", table_info, payload)
+        return
+    client = AirtableClient(token=require_token(), base_id=table_info["base_id"])
+    emit_json(client.delete_records(table_info["table_id"] or table_info["name"], record_ids))
+
+
+@schema_app.command("redoc")
+def redoc(
+    html_file: Path = typer.Argument(
+        ...,
+        help="Path to the Airtable HTML API reference file to re-parse.",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+    ),
+) -> None:
+    """Re-parse Airtable HTML docs into committed markdown schema files."""
+    written = parse_html_to_markdown(html_file, output_dir=find_md_dir())
+    typer.echo(f"Wrote {len(written)} schema files.", err=True)
+
+
+chevy_app.command("import-songs")(chevy_import_songs)
+chevy_app.command("link-releases")(chevy_link_releases)
+chevy_app.command("patch-primary-artist")(chevy_patch_primary_artist)
+chevy_app.command("patch-featured-artists")(chevy_patch_featured_artists)
+
+app.add_typer(records_app, name="records")
+app.add_typer(schema_app, name="schema")
+app.add_typer(chevy_app, name="chevy")

--- a/src/atp/md_parser.py
+++ b/src/atp/md_parser.py
@@ -1,0 +1,128 @@
+"""Parse committed Airtable schema markdown into table metadata."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TypedDict
+
+from .common import find_project_root
+from .config import AIRTABLE_DOCS_DIRNAME, DOCS_DIRNAME
+
+
+class Field(TypedDict):
+    name: str
+    field_id: str
+    type: str
+    description: str
+
+
+class Operation(TypedDict):
+    method: str
+    path: str
+
+
+class TableInfo(TypedDict):
+    name: str
+    table_id: str
+    base_id: str
+    fields: list[Field]
+    operations: dict[str, Operation]
+
+
+_READONLY_TYPES = frozenset({
+    "formula",
+    "auto number",
+    "created time",
+    "created by",
+    "last modified time",
+    "last modified by",
+    "count",
+    "rollup",
+    "lookup",
+})
+
+_SKIP_FILES = {"artists_copy.md"}
+
+_HEADING_TO_OP = {
+    "list records": "list",
+    "retrieve": "retrieve",
+    "create records": "create",
+    "update": "update",
+    "delete records": "delete",
+}
+
+def find_md_dir() -> Path:
+    return find_project_root() / DOCS_DIRNAME / AIRTABLE_DOCS_DIRNAME
+
+
+def load_tables(md_dir: Path) -> list[TableInfo]:
+    """Load all .md files in md_dir and return a list of TableInfo dicts."""
+    tables = []
+    for md_file in sorted(md_dir.glob("*.md")):
+        if md_file.name in _SKIP_FILES:
+            continue
+        table = _parse_md_file(md_file)
+        if table is not None:
+            tables.append(table)
+    return tables
+
+
+def writable_fields(table: TableInfo) -> list[Field]:
+    """Return fields that can be written (non-computed types)."""
+    return [f for f in table["fields"] if f["type"].lower() not in _READONLY_TYPES]
+
+
+def _parse_md_file(path: Path) -> TableInfo | None:
+    text = path.read_text(encoding="utf-8")
+
+    name_m = re.search(r"^# (.+)$", text, re.MULTILINE)
+    if not name_m:
+        return None
+
+    table_id_m = re.search(r"\*\*Table ID:\*\*\s*`([^`]+)`", text)
+    base_id_m = re.search(r"\*\*Base ID:\*\*\s*`([^`]+)`", text)
+
+    return TableInfo(
+        name=name_m.group(1).strip(),
+        table_id=table_id_m.group(1) if table_id_m else "",
+        base_id=base_id_m.group(1) if base_id_m else "",
+        fields=_parse_fields(text),
+        operations=_parse_operations(text),
+    )
+
+
+def _parse_fields(text: str) -> list[Field]:
+    section_m = re.search(r"## Fields\n(.*?)(?=\n---\n|\n## )", text, re.DOTALL)
+    if not section_m:
+        return []
+
+    fields: list[Field] = []
+    skip = 2  # skip header row + separator row
+    for line in section_m.group(1).splitlines():
+        if not line.startswith("|"):
+            continue
+        if skip > 0:
+            skip -= 1
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if len(cells) < 4:
+            continue
+        name, raw_fid, ftype, desc = cells[:4]
+        fid = raw_fid.strip("`")
+        if name and fid and not name.startswith("---"):
+            fields.append(Field(name=name, field_id=fid, type=ftype, description=desc))
+
+    return fields
+
+
+def _parse_operations(text: str) -> dict[str, Operation]:
+    ops: dict[str, Operation] = {}
+    for part in re.split(r"\n(?=## )", text):
+        heading = part.split("\n", 1)[0].lstrip("#").strip().lower()
+        op_key = next((v for k, v in _HEADING_TO_OP.items() if k in heading), None)
+        if op_key is None:
+            continue
+        m = re.search(r"\*\*Endpoint:\*\*\s*`([A-Z]+)\s+(/v0/[^`\s]+)`", part)
+        if m:
+            ops[op_key] = Operation(method=m.group(1), path=m.group(2))
+    return ops

--- a/src/atp/schema_parser.py
+++ b/src/atp/schema_parser.py
@@ -1,0 +1,278 @@
+"""Parse Airtable HTML docs into committed markdown schema files."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote
+
+from bs4 import BeautifulSoup, Tag
+
+from .common import find_project_root
+from .config import AIRTABLE_DOCS_DIRNAME, BASE_ID, DOCS_DIRNAME
+
+OPERATION_LABELS = {
+    "list": "List Records",
+    "retrieve": "Retrieve a Record",
+    "create": "Create Records",
+    "update": "Update / Upsert Records",
+    "delete": "Delete Records",
+}
+
+OPERATION_METHODS = {
+    "list": "GET",
+    "retrieve": "GET",
+    "create": "POST",
+    "update": "PATCH",
+    "delete": "DELETE",
+}
+
+
+def default_output_dir() -> Path:
+    return find_project_root() / DOCS_DIRNAME / AIRTABLE_DOCS_DIRNAME
+
+
+def load_soup(filepath: Path) -> BeautifulSoup:
+    print(f"Loading {filepath} ...", file=sys.stderr)
+    with filepath.open(encoding="utf-8") as fh:
+        return BeautifulSoup(fh, "lxml")
+
+
+def extract_tables(soup: BeautifulSoup) -> list[dict[str, object]]:
+    tables: list[dict[str, object]] = []
+    table_divs = soup.find_all("div", attrs={"ng-repeat": "table in application.tables"})
+
+    for div in table_divs:
+        h1 = div.find("h1", attrs={"section-name": re.compile(r"^table:[^:]+$")})
+        if h1 is None:
+            continue
+
+        section_name = h1.get("section-name", "")
+        table_key = unquote(section_name.removeprefix("table:")).strip()
+        display_name = h1.get_text(strip=True).removesuffix(" Table").strip()
+        table_id_tag = div.find("span", class_="tableId")
+        table_id = table_id_tag.get_text(strip=True) if table_id_tag else ""
+
+        fields = extract_fields(div)
+        operations: dict[str, dict[str, object]] = {}
+        for op in OPERATION_LABELS:
+            op_data = extract_operation(div, table_key, op)
+            if op_data:
+                operations[op] = op_data
+
+        tables.append({
+            "key": table_key,
+            "display_name": display_name,
+            "table_id": table_id,
+            "fields": fields,
+            "operations": operations,
+        })
+        print(f"  parsed: {display_name} ({len(fields)} fields)", file=sys.stderr)
+
+    return tables
+
+
+def extract_fields(table_div: Tag) -> list[dict[str, str]]:
+    fields: list[dict[str, str]] = []
+    for section in table_div.find_all("div", class_=lambda c: c and "fields" in c and "ng-scope" in c):
+        row = section.find("div", class_="fieldsRow")
+        if row is None:
+            continue
+
+        name_tag = row.find("span", class_="columnName")
+        id_tag = row.find("span", class_="columnId")
+        type_tag = row.find("div", class_="type")
+        desc_tag = row.find("div", class_="description")
+
+        name = name_tag.get_text(strip=True) if name_tag else ""
+        field_id = id_tag.get_text(strip=True) if id_tag else ""
+        field_type = type_tag.get_text(strip=True) if type_tag else ""
+        description = ""
+        if desc_tag:
+            for vt in desc_tag.find_all(class_="valueType"):
+                vt.decompose()
+            description = " ".join(desc_tag.get_text(" ", strip=True).split())
+
+        if name:
+            fields.append({
+                "name": name,
+                "id": field_id,
+                "type": field_type,
+                "description": description,
+            })
+
+    return fields
+
+
+def _extract_curl(section_div: Tag) -> list[str]:
+    curl_blocks: list[str] = []
+    for pre in section_div.find_all("pre"):
+        code = pre.find("code")
+        if code:
+            stripped = code.get_text().strip()
+            if stripped.startswith("curl"):
+                curl_blocks.append(stripped)
+    return curl_blocks
+
+
+def _extract_description(section_div: Tag) -> str:
+    text_div = section_div.find("div", class_="text")
+    if text_div is None:
+        return ""
+    paragraphs: list[str] = []
+    for paragraph in text_div.find_all("p", recursive=True):
+        text = " ".join(paragraph.get_text(" ", strip=True).split())
+        if text and len(text) > 20:
+            paragraphs.append(text)
+            if len(paragraphs) == 2:
+                break
+    return "\n\n".join(paragraphs)
+
+
+def _extract_parameters(section_div: Tag) -> list[dict[str, str]]:
+    params: list[dict[str, str]] = []
+    for name_div in section_div.find_all("div", class_="paginationName"):
+        raw = name_div.get_text(" ", strip=True)
+        code_type = name_div.find("code", class_="type")
+        param_type = code_type.get_text(strip=True) if code_type else ""
+        required_tag = name_div.find("span", class_="required")
+        optional_tag = name_div.find("span", class_="optional")
+        required = "required" if required_tag else "optional"
+
+        name = raw
+        if code_type:
+            name = name.replace(code_type.get_text(strip=True), "").strip()
+        if required_tag:
+            name = name.replace("required", "").strip()
+        if optional_tag:
+            name = name.replace("optional", "").strip()
+
+        desc = ""
+        next_sib = name_div.find_next_sibling("div", class_="paginationDescription")
+        if next_sib:
+            desc = " ".join(next_sib.get_text(" ", strip=True).split())[:300]
+
+        params.append({
+            "name": name,
+            "type": param_type,
+            "required": required,
+            "description": desc,
+        })
+    return params
+
+
+def extract_operation(table_div: Tag, table_key: str, op: str) -> dict[str, object] | None:
+    h2 = table_div.find(
+        "h2",
+        attrs={"section-name": lambda v: v and unquote(v) == f"table:{table_key}:{op}"},
+    )
+    if h2 is None or h2.parent is None:
+        return None
+
+    return {
+        "op": op,
+        "description": _extract_description(h2.parent),
+        "curl_commands": _extract_curl(h2.parent),
+        "parameters": _extract_parameters(h2.parent) if op == "list" else [],
+    }
+
+
+def _safe_filename(name: str) -> str:
+    safe = re.sub(r"[^\w\s-]", " ", name.lower())
+    safe = re.sub(r"[\s_]+", "-", safe.strip()).strip("-")
+    return f"{safe}.md"
+
+
+def _escape_md(text: str) -> str:
+    return text.replace("|", "\\|")
+
+
+def render_markdown(table: dict[str, object]) -> str:
+    lines: list[str] = []
+    display_name = str(table["display_name"])
+    table_id = str(table["table_id"])
+    lines.append(f"# {display_name}\n")
+    lines.append(f"**Table ID:** `{table_id}`  ")
+    lines.append(f"**Base ID:** `{BASE_ID}`\n")
+    lines.append("---\n")
+    lines.append("## Fields\n")
+
+    fields = table["fields"]
+    if isinstance(fields, list) and fields:
+        lines.append("| Field Name | Field ID | Type | Description |")
+        lines.append("|------------|----------|------|-------------|")
+        for field in fields:
+            if not isinstance(field, dict):
+                continue
+            lines.append(
+                "| "
+                f"{_escape_md(str(field.get('name', '')))} | "
+                f"`{_escape_md(str(field.get('id', '')))} `".replace(" `", "`")
+                + " | "
+                f"{_escape_md(str(field.get('type', '')))} | "
+                f"{_escape_md(str(field.get('description', '')))} |"
+            )
+    else:
+        lines.append("_No fields found._")
+    lines.append("")
+
+    operations = table["operations"]
+    if isinstance(operations, dict):
+        for op, label in OPERATION_LABELS.items():
+            if op not in operations:
+                continue
+            op_data = operations[op]
+            if not isinstance(op_data, dict):
+                continue
+            lines.append("---\n")
+            lines.append(f"## {label}\n")
+            lines.append(f"**Endpoint:** `{OPERATION_METHODS[op]} /v0/{BASE_ID}/{table['key']}`\n")
+            description = str(op_data.get("description", ""))
+            if description:
+                lines.append(description)
+                lines.append("")
+
+            curl_commands = op_data.get("curl_commands")
+            if isinstance(curl_commands, list):
+                for curl in curl_commands:
+                    lines.append("```bash")
+                    lines.append(str(curl))
+                    lines.append("```\n")
+
+            parameters = op_data.get("parameters")
+            if isinstance(parameters, list) and parameters:
+                lines.append("### Query Parameters\n")
+                lines.append("| Parameter | Type | Required | Description |")
+                lines.append("|-----------|------|----------|-------------|")
+                for param in parameters:
+                    if not isinstance(param, dict):
+                        continue
+                    lines.append(
+                        f"| `{_escape_md(str(param.get('name', '')))}` | "
+                        f"{_escape_md(str(param.get('type', '')))} | "
+                        f"{param.get('required', '')} | "
+                        f"{_escape_md(str(param.get('description', '')))} |"
+                    )
+                lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def parse_html_to_markdown(html_file: Path, output_dir: Path | None = None) -> list[Path]:
+    target_dir = output_dir or default_output_dir()
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    soup = load_soup(html_file)
+    tables = extract_tables(soup)
+    written: list[Path] = []
+
+    print(f"\nWriting {len(tables)} markdown files to {target_dir}/", file=sys.stderr)
+    for table in tables:
+        filename = _safe_filename(str(table["display_name"]))
+        out_path = target_dir / filename
+        out_path.write_text(render_markdown(table), encoding="utf-8")
+        written.append(out_path)
+        print(f"  -> {out_path}", file=sys.stderr)
+
+    print("\nDone.", file=sys.stderr)
+    return written

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,163 @@
+"""Shared fixtures for the ParseAirTableAPI test suite."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def mock_session() -> MagicMock:
+    """A plain MagicMock that stands in for requests.Session."""
+    return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# Synthetic .md content
+# Two real tables + the one file that must be skipped.
+# ---------------------------------------------------------------------------
+
+_ARTISTS_MD = """\
+# Artists
+
+**Table ID:** `tblABC123`
+**Base ID:** `appTEST0001`
+
+## Fields
+
+| Name | Field ID | Type | Description |
+| ---- | -------- | ---- | ----------- |
+| Artist Name | `fldABC001` | Text | The artist name |
+| Genre Formula | `fldABC002` | Formula | Auto-computed |
+| Track Count | `fldABC003` | Count | Count rollup |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appTEST0001/tblABC123`
+
+## Create Records
+
+**Endpoint:** `POST /v0/appTEST0001/tblABC123`
+
+## Update
+
+**Endpoint:** `PATCH /v0/appTEST0001/tblABC123`
+
+## Delete Records
+
+**Endpoint:** `DELETE /v0/appTEST0001/tblABC123`
+"""
+
+_RECORDINGS_MD = """\
+# Recordings
+
+**Table ID:** `tblDEF456`
+**Base ID:** `appTEST0001`
+
+## Fields
+
+| Name | Field ID | Type | Description |
+| ---- | -------- | ---- | ----------- |
+| Title | `fldDEF001` | Text | Track title |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appTEST0001/tblDEF456`
+
+## Create Records
+
+**Endpoint:** `POST /v0/appTEST0001/tblDEF456`
+"""
+
+_ARTISTS_COPY_MD = """\
+# Artists Copy
+
+**Table ID:** `tblGHI789`
+**Base ID:** `appTEST0001`
+"""
+
+# ---------------------------------------------------------------------------
+# Linked-field .md content for expand tests
+# ---------------------------------------------------------------------------
+
+_RELEASES_LINK_MD = """\
+# Releases
+
+**Table ID:** `tblREL001`
+**Base ID:** `appTEST0001`
+
+## Fields
+
+| Name | Field ID | Type | Description |
+| ---- | -------- | ---- | ----------- |
+| Name | `fldREL001` | Text | Release name |
+| Recordings | `fldREL002` | Link to another record | Array of linked records IDs from the Recordings table. |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appTEST0001/tblREL001`
+"""
+
+_RECORDINGS_LINK_MD = """\
+# Recordings
+
+**Table ID:** `tblREC001`
+**Base ID:** `appTEST0001`
+
+## Fields
+
+| Name | Field ID | Type | Description |
+| ---- | -------- | ---- | ----------- |
+| Title | `fldREC001` | Text | Track title |
+| Compositions | `fldREC002` | Link to another record | Array of linked records IDs from the Compositions table. |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appTEST0001/tblREC001`
+"""
+
+_COMPOSITIONS_LINK_MD = """\
+# Compositions
+
+**Table ID:** `tblCOM001`
+**Base ID:** `appTEST0001`
+
+## Fields
+
+| Name | Field ID | Type | Description |
+| ---- | -------- | ---- | ----------- |
+| Title | `fldCOM001` | Text | Composition title |
+
+---
+
+## List Records
+
+**Endpoint:** `GET /v0/appTEST0001/tblCOM001`
+"""
+
+
+@pytest.fixture
+def tmp_md_dir(tmp_path: Path) -> Path:
+    """A temp directory with two valid .md files and the skip-listed artists_copy.md."""
+    (tmp_path / "artists.md").write_text(_ARTISTS_MD, encoding="utf-8")
+    (tmp_path / "recordings.md").write_text(_RECORDINGS_MD, encoding="utf-8")
+    (tmp_path / "artists_copy.md").write_text(_ARTISTS_COPY_MD, encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture
+def tmp_link_md_dir(tmp_path: Path) -> Path:
+    """A temp directory with three tables that have 'Link to another record' fields."""
+    (tmp_path / "releases.md").write_text(_RELEASES_LINK_MD, encoding="utf-8")
+    (tmp_path / "recordings.md").write_text(_RECORDINGS_LINK_MD, encoding="utf-8")
+    (tmp_path / "compositions.md").write_text(_COMPOSITIONS_LINK_MD, encoding="utf-8")
+    return tmp_path

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,81 @@
+"""Tests for atp.api.AirtableClient."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from atp.api import AirtableClient
+
+
+@pytest.fixture
+def client(mock_session: MagicMock) -> AirtableClient:
+    return AirtableClient(token="faketoken", base_id="appTEST0001", session=mock_session)
+
+
+def test_constructor_sets_auth_header(mock_session: MagicMock) -> None:
+    AirtableClient(token="faketoken", base_id="appTEST0001", session=mock_session)
+    mock_session.headers.update.assert_called_once_with({
+        "Authorization": "Bearer faketoken",
+        "Content-Type": "application/json",
+    })
+
+
+def test_list_records_calls_get(client: AirtableClient, mock_session: MagicMock) -> None:
+    mock_session.get.return_value.json.return_value = {}
+    client.list_records("tblABC123")
+    mock_session.get.assert_called_once()
+    url = mock_session.get.call_args.args[0]
+    assert "appTEST0001" in url
+    assert "tblABC123" in url
+
+
+def test_list_records_passes_filter(client: AirtableClient, mock_session: MagicMock) -> None:
+    mock_session.get.return_value.json.return_value = {}
+    client.list_records("tblABC123", filter_formula="{Name}='Alice'")
+    params = mock_session.get.call_args.kwargs["params"]
+    assert params["filterByFormula"] == "{Name}='Alice'"
+
+
+def test_list_records_passes_max_records(client: AirtableClient, mock_session: MagicMock) -> None:
+    mock_session.get.return_value.json.return_value = {}
+    client.list_records("tblABC123", max_records=10)
+    params = mock_session.get.call_args.kwargs["params"]
+    assert params["maxRecords"] == 10
+
+
+def test_list_records_omits_empty_params(client: AirtableClient, mock_session: MagicMock) -> None:
+    mock_session.get.return_value.json.return_value = {}
+    client.list_records("tblABC123")
+    params = mock_session.get.call_args.kwargs.get("params") or {}
+    assert "filterByFormula" not in params
+    assert "maxRecords" not in params
+
+
+def test_retrieve_record_calls_get_with_record_id(client: AirtableClient, mock_session: MagicMock) -> None:
+    mock_session.get.return_value.json.return_value = {}
+    client.retrieve_record("tblABC123", "recABC123")
+    url = mock_session.get.call_args.args[0]
+    assert url.endswith("/recABC123")
+
+
+def test_create_records_calls_post(client: AirtableClient, mock_session: MagicMock) -> None:
+    mock_session.post.return_value.json.return_value = {}
+    client.create_records("tblABC123", [{"Name": "Alice"}])
+    body = mock_session.post.call_args.kwargs["json"]
+    assert body == {"records": [{"fields": {"Name": "Alice"}}]}
+
+
+def test_update_records_calls_patch(client: AirtableClient, mock_session: MagicMock) -> None:
+    mock_session.patch.return_value.json.return_value = {}
+    record: dict[str, object] = {"id": "recABC123", "fields": {"Name": "Bob"}}
+    client.update_records("tblABC123", [record])
+    body = mock_session.patch.call_args.kwargs["json"]
+    assert body == {"records": [record]}
+
+
+def test_delete_records_calls_delete(client: AirtableClient, mock_session: MagicMock) -> None:
+    mock_session.delete.return_value.json.return_value = {}
+    client.delete_records("tblABC123", ["recAAA", "recBBB"])
+    params = mock_session.delete.call_args.kwargs["params"]
+    assert params == [("records[]", "recAAA"), ("records[]", "recBBB")]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,44 @@
+"""Tests for atp.main (CLI entry point)."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from atp.main import app
+
+runner = CliRunner()
+
+
+def test_records_list_exits_1_without_token() -> None:
+    with patch("atp.main.require_token", side_effect=SystemExit(1)):
+        result = runner.invoke(app, ["records", "list", "Artists"])
+    assert result.exit_code == 1
+
+
+def test_records_create_previews_by_default() -> None:
+    with patch(
+        "atp.main._find_table",
+        return_value={"name": "Artists", "table_id": "tblABC123", "base_id": "appTEST0001"},
+    ):
+        result = runner.invoke(app, ["records", "create", "Artists", "--field", "Name=Alice"])
+    assert result.exit_code == 0
+    assert '"action": "create"' in result.stdout
+    assert '"apply": false' in result.stdout
+
+
+def test_records_create_apply_calls_live_client() -> None:
+    fake_client = type("FakeClient", (), {"create_records": lambda self, table_id, rows: {"table_id": table_id, "rows": rows}})()
+    with patch(
+        "atp.main._find_table",
+        return_value={"name": "Artists", "table_id": "tblABC123", "base_id": "appTEST0001"},
+    ), patch("atp.main.require_token", return_value="token"), patch("atp.main.AirtableClient", return_value=fake_client):
+        result = runner.invoke(app, ["records", "create", "Artists", "--field", "Name=Alice", "--apply"])
+    assert result.exit_code == 0
+    assert '"table_id": "tblABC123"' in result.stdout
+
+
+def test_atp_help_mentions_airtable_pbgl() -> None:
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "AirTable PBGL" in result.stdout

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -1,0 +1,328 @@
+"""Tests for atp.expand."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from atp.expand import ExpandConfig, SpineEntry, build_link_info, expand_record
+from atp.md_parser import Field, TableInfo, load_tables
+
+# Real spine table IDs (from data-model.md)
+_RELEASES_ID = "tbl7rjVKUd5faZ7fV"
+_RECORDINGS_ID = "tblESvQQmOBbEXAH0"
+_COMPOSITIONS_ID = "tblomWINKPjfgAVpo"
+_SONGWRITERS_ID = "tbl2KLh2RIrS5AmSX"
+_PUBLISHERS_ID = "tbl6TNKQRPfY3hXZ2"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_table(name: str, table_id: str, fields: list[Field]) -> TableInfo:
+    return TableInfo(
+        name=name,
+        table_id=table_id,
+        base_id="appTEST0001",
+        fields=fields,
+        operations={},
+    )
+
+
+def _link_field(name: str, target_table_name: str) -> Field:
+    return Field(
+        name=name,
+        field_id=f"fld{name[:3].upper()}",
+        type="Link to another record",
+        description=f"Array of linked records IDs from the {target_table_name} table.",
+    )
+
+
+def _text_field(name: str) -> Field:
+    return Field(name=name, field_id="fldTXT001", type="Text", description="A text field")
+
+
+def _make_record(record_id: str, fields: dict) -> dict:
+    return {"id": record_id, "fields": fields}
+
+
+# ---------------------------------------------------------------------------
+# build_link_info
+# ---------------------------------------------------------------------------
+
+def test_build_link_info_standard_link() -> None:
+    releases = _make_table("Releases", "tblREL", [_link_field("Recordings", "Recordings")])
+    recordings = _make_table("Recordings", "tblREC", [_text_field("Title")])
+    result = build_link_info([releases, recordings])
+    assert result == {"tblREL": {"Recordings": "tblREC"}}
+
+
+def test_build_link_info_self_referential() -> None:
+    publishers = _make_table("Publishers", "tblPUB", [_link_field("In Care Of", "Publishers")])
+    result = build_link_info([publishers])
+    assert result == {"tblPUB": {"In Care Of": "tblPUB"}}
+
+
+def test_build_link_info_skips_no_pattern_match() -> None:
+    field = Field(
+        name="Misc",
+        field_id="fldMISC",
+        type="Link to another record",
+        description="Some unrelated description",
+    )
+    table = _make_table("X", "tblX", [field])
+    result = build_link_info([table])
+    assert result == {}
+
+
+def test_build_link_info_skips_missing_target_table() -> None:
+    releases = _make_table("Releases", "tblREL", [_link_field("SCRATCH", "SCRATCH")])
+    result = build_link_info([releases])
+    assert result == {}
+
+
+def test_build_link_info_excludes_non_link_fields() -> None:
+    releases = _make_table("Releases", "tblREL", [_text_field("Title")])
+    result = build_link_info([releases])
+    assert result == {}
+
+
+def test_build_link_info_with_loaded_tables(tmp_link_md_dir: Path) -> None:
+    tables = load_tables(tmp_link_md_dir)
+    link_info = build_link_info(tables)
+    releases = next(t for t in tables if t["name"] == "Releases")
+    recordings = next(t for t in tables if t["name"] == "Recordings")
+    assert link_info[releases["table_id"]]["Recordings"] == recordings["table_id"]
+
+
+# ---------------------------------------------------------------------------
+# expand_record — basic behavior
+# ---------------------------------------------------------------------------
+
+def test_expand_record_depth_zero_strips_raw_id_lists() -> None:
+    client = MagicMock()
+    real_id = "recABCDEFGHIJKLMN"
+    record = _make_record("recABC", {"Recordings": [real_id]})
+    link_info = {"tblREL": {"Recordings": "tblREC"}}
+    result = expand_record(record, "tblREL", link_info, client, depth=0)
+    assert "Recordings" not in result["fields"]
+    client.retrieve_record.assert_not_called()
+
+
+def test_expand_record_field_not_in_link_info_untouched() -> None:
+    client = MagicMock()
+    record = _make_record("recABC", {"Title": "My Song"})
+    link_info: dict = {}
+    result = expand_record(record, "tblREL", link_info, client, depth=3)
+    assert result["fields"]["Title"] == "My Song"
+    client.retrieve_record.assert_not_called()
+
+
+def test_expand_record_empty_list_field_not_fetched() -> None:
+    client = MagicMock()
+    record = _make_record("recABC", {"Recordings": []})
+    link_info = {"tblREL": {"Recordings": "tblREC"}}
+    result = expand_record(record, "tblREL", link_info, client, depth=3)
+    client.retrieve_record.assert_not_called()
+    assert result["fields"]["Recordings"] == []
+
+
+def test_expand_record_table_not_in_spine_strips_all_linked_fields() -> None:
+    """A table with no spine entry has all its non-empty linked fields stripped."""
+    client = MagicMock()
+    record = _make_record("recABC", {"Recordings": ["recREC001ABCDEFGH"], "Title": "Demo"})
+    link_info = {"tblUNKNOWN": {"Recordings": "tblREC"}}
+    result = expand_record(record, "tblUNKNOWN", link_info, client, depth=3)
+    assert "Recordings" not in result["fields"]
+    assert result["fields"]["Title"] == "Demo"
+    client.retrieve_record.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# expand_record — spine traversal: Releases
+# ---------------------------------------------------------------------------
+
+def test_expand_record_releases_follows_recordings() -> None:
+    """Releases spine: Recordings is followed; unrecognized linked fields are stripped."""
+    client = MagicMock()
+    linked_record = _make_record("recREC001ABCDEFGH", {"Title": "Song A"})
+    client.retrieve_record.return_value = linked_record
+    record = _make_record("recREL001ABCDEFGH", {
+        "Recordings": ["recREC001ABCDEFGH"],
+        "Admin Link": ["recADM001ABCDEFGH"],
+    })
+    link_info = {
+        _RELEASES_ID: {
+            "Recordings": _RECORDINGS_ID,
+            "Admin Link": "tblADMIN",
+        }
+    }
+    result = expand_record(record, _RELEASES_ID, link_info, client, depth=1)
+    assert "Admin Link" not in result["fields"]
+    assert result["fields"]["Recordings"] == [linked_record]
+    client.retrieve_record.assert_called_once_with(_RECORDINGS_ID, "recREC001ABCDEFGH")
+
+
+def test_expand_record_releases_name_only_primary_artist() -> None:
+    """Releases spine: Primary Artist is returned as {id, _name} without recursing."""
+    client = MagicMock()
+    artist_record = _make_record("recART001ABCDEFGH", {
+        "Artist Name": "Kendrick Lamar",
+        "Some Link": ["recOTH001ABCDEFGH"],
+    })
+    client.retrieve_record.return_value = artist_record
+    record = _make_record("recREL001ABCDEFGH", {"Primary Artist": ["recART001ABCDEFGH"]})
+    link_info = {_RELEASES_ID: {"Primary Artist": "tblARTISTS"}}
+    config = ExpandConfig(primary_field_map={"tblARTISTS": "Artist Name"})
+    result = expand_record(record, _RELEASES_ID, link_info, client, depth=3, config=config)
+    assert result["fields"]["Primary Artist"] == [{"id": "recART001ABCDEFGH", "_name": "Kendrick Lamar"}]
+    client.retrieve_record.assert_called_once_with("tblARTISTS", "recART001ABCDEFGH")
+
+
+def test_expand_record_releases_name_only_uses_cache() -> None:
+    """Name-only cache prevents duplicate HTTP fetches for the same record."""
+    client = MagicMock()
+    cache_key = ("tblARTISTS", "recART001ABCDEFGH")
+    config = ExpandConfig(
+        primary_field_map={"tblARTISTS": "Artist Name"},
+        name_cache={cache_key: "Drake"},
+    )
+    record = _make_record("recREL001ABCDEFGH", {"Primary Artist": ["recART001ABCDEFGH"]})
+    link_info = {_RELEASES_ID: {"Primary Artist": "tblARTISTS"}}
+    result = expand_record(record, _RELEASES_ID, link_info, client, depth=3, config=config)
+    assert result["fields"]["Primary Artist"] == [{"id": "recART001ABCDEFGH", "_name": "Drake"}]
+    client.retrieve_record.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# expand_record — spine traversal: Recordings
+# ---------------------------------------------------------------------------
+
+def test_expand_record_recordings_follows_compositions() -> None:
+    """Recordings spine: Compositions is followed."""
+    client = MagicMock()
+    linked_record = _make_record("recCOM001ABCDEFGH", {"Title": "My Composition"})
+    client.retrieve_record.return_value = linked_record
+    record = _make_record("recREC001ABCDEFGH", {"Compositions": ["recCOM001ABCDEFGH"]})
+    link_info = {_RECORDINGS_ID: {"Compositions": _COMPOSITIONS_ID}}
+    result = expand_record(record, _RECORDINGS_ID, link_info, client, depth=1)
+    assert result["fields"]["Compositions"] == [linked_record]
+    client.retrieve_record.assert_called_once_with(_COMPOSITIONS_ID, "recCOM001ABCDEFGH")
+
+
+def test_expand_record_recordings_strips_non_spine_link() -> None:
+    """Recordings spine: A linked field not in follow or name_only is stripped."""
+    client = MagicMock()
+    client.retrieve_record.return_value = _make_record("recCOM001ABCDEFGH", {})
+    record = _make_record("recREC001ABCDEFGH", {
+        "Compositions": ["recCOM001ABCDEFGH"],
+        "REGISTRATION PROJECT (PRO +MLC)": ["recREG001ABCDEFGH"],
+    })
+    link_info = {
+        _RECORDINGS_ID: {
+            "Compositions": _COMPOSITIONS_ID,
+            "REGISTRATION PROJECT (PRO +MLC)": "tblREGPRO",
+        }
+    }
+    result = expand_record(record, _RECORDINGS_ID, link_info, client, depth=1)
+    assert "REGISTRATION PROJECT (PRO +MLC)" not in result["fields"]
+
+
+# ---------------------------------------------------------------------------
+# expand_record — spine traversal: Compositions
+# ---------------------------------------------------------------------------
+
+def test_expand_record_compositions_songwriter_regex_followed() -> None:
+    """Compositions spine: 'Songwriter 1' matches follow_re and is expanded."""
+    client = MagicMock()
+    sw_record = _make_record("recSW1001ABCDEFGH", {"Name": "Alice"})
+    client.retrieve_record.return_value = sw_record
+    record = _make_record("recCOM001ABCDEFGH", {"Songwriter 1": ["recSW1001ABCDEFGH"]})
+    link_info = {_COMPOSITIONS_ID: {"Songwriter 1": _SONGWRITERS_ID}}
+    result = expand_record(record, _COMPOSITIONS_ID, link_info, client, depth=1)
+    assert result["fields"]["Songwriter 1"] == [sw_record]
+    client.retrieve_record.assert_called_once_with(_SONGWRITERS_ID, "recSW1001ABCDEFGH")
+
+
+def test_expand_record_compositions_publisher_regex_name_only() -> None:
+    """Compositions spine: 'Songwriter 1 Original Pub 1' matches name_only_re."""
+    client = MagicMock()
+    pub_record = _make_record("recPUB001ABCDEFGH", {
+        "Publisher Name": "ASCAP Music",
+        "Other Link": ["recOTH001ABCDEFGH"],
+    })
+    client.retrieve_record.return_value = pub_record
+    record = _make_record("recCOM001ABCDEFGH", {
+        "Songwriter 1 Original Pub 1": ["recPUB001ABCDEFGH"],
+    })
+    link_info = {_COMPOSITIONS_ID: {"Songwriter 1 Original Pub 1": _PUBLISHERS_ID}}
+    config = ExpandConfig(primary_field_map={_PUBLISHERS_ID: "Publisher Name"})
+    result = expand_record(record, _COMPOSITIONS_ID, link_info, client, depth=3, config=config)
+    assert result["fields"]["Songwriter 1 Original Pub 1"] == [
+        {"id": "recPUB001ABCDEFGH", "_name": "ASCAP Music"}
+    ]
+
+
+def test_expand_record_compositions_strips_back_reference() -> None:
+    """Compositions spine: 'All Releases' is not in follow or name_only → stripped."""
+    client = MagicMock()
+    record = _make_record("recCOM001ABCDEFGH", {"All Releases": ["recREL001ABCDEFGH"]})
+    link_info = {_COMPOSITIONS_ID: {"All Releases": _RELEASES_ID}}
+    result = expand_record(record, _COMPOSITIONS_ID, link_info, client, depth=3)
+    assert "All Releases" not in result["fields"]
+    client.retrieve_record.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# expand_record — spine traversal: leaf tables
+# ---------------------------------------------------------------------------
+
+def test_expand_record_songwriters_leaf_strips_linked_preserves_scalars() -> None:
+    """Songwriters is a leaf: all linked fields stripped, scalar fields preserved."""
+    client = MagicMock()
+    record = _make_record("recSW1001ABCDEFGH", {
+        "Name": "Alice",
+        "PRO": "ASCAP",
+        "Publisher": ["recPUB001ABCDEFGH"],
+    })
+    link_info = {_SONGWRITERS_ID: {"Publisher": _PUBLISHERS_ID}}
+    result = expand_record(record, _SONGWRITERS_ID, link_info, client, depth=3)
+    assert result["fields"]["Name"] == "Alice"
+    assert result["fields"]["PRO"] == "ASCAP"
+    assert "Publisher" not in result["fields"]
+    client.retrieve_record.assert_not_called()
+
+
+def test_expand_record_publishers_leaf_strips_linked_preserves_scalars() -> None:
+    """Publishers is a leaf: all linked fields stripped, scalar fields preserved."""
+    client = MagicMock()
+    record = _make_record("recPUB001ABCDEFGH", {
+        "Publisher Name": "BMI Sub-Publisher",
+        "In Care Of": ["recPUB002ABCDEFGH"],
+    })
+    link_info = {_PUBLISHERS_ID: {"In Care Of": _PUBLISHERS_ID}}
+    result = expand_record(record, _PUBLISHERS_ID, link_info, client, depth=3)
+    assert result["fields"]["Publisher Name"] == "BMI Sub-Publisher"
+    assert "In Care Of" not in result["fields"]
+    client.retrieve_record.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# expand_record — depth limiting
+# ---------------------------------------------------------------------------
+
+def test_expand_record_depth_limits_recursion() -> None:
+    """depth=1: Releases→Recordings is expanded; Recordings→Compositions is stripped."""
+    rec_id = "recREC001ABCDEFGH"
+    com_id = "recCOM001ABCDEFGH"
+    child = _make_record(rec_id, {"Compositions": [com_id]})
+    client = MagicMock()
+    client.retrieve_record.return_value = child
+    record = _make_record("recREL001ABCDEFGH", {"Recordings": [rec_id]})
+    link_info = {
+        _RELEASES_ID: {"Recordings": _RECORDINGS_ID},
+        _RECORDINGS_ID: {"Compositions": _COMPOSITIONS_ID},
+    }
+    result = expand_record(record, _RELEASES_ID, link_info, client, depth=1)
+    client.retrieve_record.assert_called_once_with(_RECORDINGS_ID, rec_id)
+    assert "Compositions" not in result["fields"]["Recordings"][0]["fields"]

--- a/tests/test_md_parser.py
+++ b/tests/test_md_parser.py
@@ -1,0 +1,71 @@
+"""Tests for atp.md_parser."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atp.md_parser import find_project_root, load_tables, writable_fields
+
+
+def test_load_tables_returns_correct_count(tmp_md_dir: Path) -> None:
+    tables = load_tables(tmp_md_dir)
+    assert len(tables) == 2
+
+
+def test_load_tables_skips_artists_copy(tmp_md_dir: Path) -> None:
+    tables = load_tables(tmp_md_dir)
+    names = [t["name"] for t in tables]
+    assert "Artists Copy" not in names
+
+
+def test_load_tables_returns_table_info_structure(tmp_md_dir: Path) -> None:
+    tables = load_tables(tmp_md_dir)
+    for table in tables:
+        assert set(table.keys()) >= {"name", "table_id", "base_id", "fields", "operations"}
+
+
+def test_load_tables_parses_ids(tmp_md_dir: Path) -> None:
+    tables = load_tables(tmp_md_dir)
+    ids = {t["table_id"] for t in tables}
+    assert "tblABC123" in ids
+    assert "tblDEF456" in ids
+
+
+def test_load_tables_parses_base_id(tmp_md_dir: Path) -> None:
+    tables = load_tables(tmp_md_dir)
+    for table in tables:
+        assert table["base_id"] == "appTEST0001"
+
+
+def test_load_tables_parses_operations(tmp_md_dir: Path) -> None:
+    tables = load_tables(tmp_md_dir)
+    artists = next(t for t in tables if t["name"] == "Artists")
+    assert artists["operations"]["list"]["method"] == "GET"
+    assert artists["operations"]["create"]["method"] == "POST"
+
+
+def test_writable_fields_excludes_formula(tmp_md_dir: Path) -> None:
+    tables = load_tables(tmp_md_dir)
+    artists = next(t for t in tables if t["name"] == "Artists")
+    types = [f["type"].lower() for f in writable_fields(artists)]
+    assert "formula" not in types
+
+
+def test_writable_fields_excludes_count(tmp_md_dir: Path) -> None:
+    tables = load_tables(tmp_md_dir)
+    artists = next(t for t in tables if t["name"] == "Artists")
+    types = [f["type"].lower() for f in writable_fields(artists)]
+    assert "count" not in types
+
+
+def test_writable_fields_keeps_text(tmp_md_dir: Path) -> None:
+    tables = load_tables(tmp_md_dir)
+    artists = next(t for t in tables if t["name"] == "Artists")
+    types = [f["type"].lower() for f in writable_fields(artists)]
+    assert "text" in types
+
+
+def test_find_project_root_has_pyproject() -> None:
+    root = find_project_root()
+    assert (root / "pyproject.toml").exists()

--- a/tests/test_schema_parser.py
+++ b/tests/test_schema_parser.py
@@ -1,0 +1,38 @@
+"""Tests for atp.schema_parser."""
+from __future__ import annotations
+
+from atp.schema_parser import parse_html_to_markdown
+
+
+def test_parse_html_to_markdown_writes_markdown_files(tmp_path) -> None:
+    html = """\
+<html>
+  <body>
+    <div ng-repeat="table in application.tables">
+      <h1 section-name="table:artists">Artists Table</h1>
+      <span class="tableId">tblABC123</span>
+      <div class="docSection fields ng-scope">
+        <div class="fieldsRow">
+          <span class="columnName">Artist Name</span>
+          <span class="columnId">fldABC001</span>
+          <div class="type">Text</div>
+          <div class="description">The artist name</div>
+        </div>
+      </div>
+      <div class="docSection">
+        <h2 section-name="table:artists:list">List</h2>
+        <div class="text"><p>List artist records.</p></div>
+      </div>
+    </div>
+  </body>
+</html>
+"""
+    html_path = tmp_path / "airtable.html"
+    output_dir = tmp_path / "output"
+    html_path.write_text(html, encoding="utf-8")
+
+    written = parse_html_to_markdown(html_path, output_dir=output_dir)
+
+    assert len(written) == 1
+    assert written[0].name == "artists.md"
+    assert written[0].exists()

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+say() {
+  printf '%s\n' "$1"
+}
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    say "Missing required command: $1"
+    exit 1
+  fi
+}
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT"
+
+if [ ! -f "pyproject.toml" ]; then
+  say "update.sh must run from the AirTable_PBGL repo."
+  exit 1
+fi
+
+need_cmd git
+need_cmd uv
+
+say "Fetching tags..."
+git fetch --tags
+
+LATEST_TAG="$(git tag --sort=-v:refname | head -n 1)"
+
+if [ -z "$LATEST_TAG" ]; then
+  say "No tags found. Updating current branch dependencies instead."
+  uv sync
+  exit 0
+fi
+
+say "Latest tagged release: $LATEST_TAG"
+CURRENT_REF="$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)"
+say "Current version: $CURRENT_REF"
+
+if [ "$CURRENT_REF" != "$LATEST_TAG" ]; then
+  say "Checking out $LATEST_TAG..."
+  git checkout "$LATEST_TAG"
+fi
+
+say "Syncing Python dependencies with uv..."
+uv sync
+
+say "Update complete."

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,725 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "airtable-pbgl"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "lxml" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "textual" },
+    { name = "typer" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "beautifulsoup4", specifier = ">=4.14.3" },
+    { name = "lxml", specifier = ">=6.0.2" },
+    { name = "python-dotenv", specifier = ">=1.0" },
+    { name = "requests", specifier = ">=2.32" },
+    { name = "textual", specifier = ">=0.80" },
+    { name = "typer", specifier = ">=0.15" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy" },
+    { name = "pytest", specifier = ">=8" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8c/74fedc9663dcf168b0a059d4ea756ecae4da77a489048f94b5f512a8d0b3/coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1", size = 219576, upload-time = "2026-03-17T10:31:09.045Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c9/44fb661c55062f0818a6ffd2685c67aa30816200d5f2817543717d4b92eb/coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3", size = 219942, upload-time = "2026-03-17T10:31:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935, upload-time = "2026-03-17T10:31:12.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541, upload-time = "2026-03-17T10:31:14.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780, upload-time = "2026-03-17T10:31:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912, upload-time = "2026-03-17T10:31:17.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165, upload-time = "2026-03-17T10:31:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908, upload-time = "2026-03-17T10:31:21.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873, upload-time = "2026-03-17T10:31:23.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030, upload-time = "2026-03-17T10:31:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694, upload-time = "2026-03-17T10:31:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469, upload-time = "2026-03-17T10:31:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f5/be742fec31118f02ce42b21c6af187ad6a344fed546b56ca60caacc6a9a0/coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85", size = 222112, upload-time = "2026-03-17T10:31:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/7732d648ab9d069a46e686043241f01206348e2bbf128daea85be4d6414b/coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b", size = 222923, upload-time = "2026-03-17T10:31:33.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/af/fea819c12a095781f6ccd504890aaddaf88b8fab263c4940e82c7b770124/coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664", size = 221540, upload-time = "2026-03-17T10:31:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/17879af479df7fbbd44bd528a31692a48f6b25055d16482fdf5cdb633805/coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d", size = 220262, upload-time = "2026-03-17T10:31:37.184Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4c/d20e554f988c8f91d6a02c5118f9abbbf73a8768a3048cb4962230d5743f/coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0", size = 220617, upload-time = "2026-03-17T10:31:39.245Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912, upload-time = "2026-03-17T10:31:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987, upload-time = "2026-03-17T10:31:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416, upload-time = "2026-03-17T10:31:45.769Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558, upload-time = "2026-03-17T10:31:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163, upload-time = "2026-03-17T10:31:50.125Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981, upload-time = "2026-03-17T10:31:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604, upload-time = "2026-03-17T10:31:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321, upload-time = "2026-03-17T10:31:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502, upload-time = "2026-03-17T10:31:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688, upload-time = "2026-03-17T10:32:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4f/f5df9007e50b15e53e01edea486814783a7f019893733d9e4d6caad75557/coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a", size = 222788, upload-time = "2026-03-17T10:32:02.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851, upload-time = "2026-03-17T10:32:04.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104, upload-time = "2026-03-17T10:32:06.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/9c/b4b0c54d84da4a94b37bd44151e46d5e583c9534c7e02250b961b1b6d8a8/librt-0.8.1.tar.gz", hash = "sha256:be46a14693955b3bd96014ccbdb8339ee8c9346fbe11c1b78901b55125f14c73", size = 177471, upload-time = "2026-02-17T16:13:06.101Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/21/d39b0a87ac52fc98f621fb6f8060efb017a767ebbbac2f99fbcbc9ddc0d7/librt-0.8.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a28f2612ab566b17f3698b0da021ff9960610301607c9a5e8eaca62f5e1c350a", size = 66516, upload-time = "2026-02-17T16:11:41.604Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f1/46375e71441c43e8ae335905e069f1c54febee63a146278bcee8782c84fd/librt-0.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:60a78b694c9aee2a0f1aaeaa7d101cf713e92e8423a941d2897f4fa37908dab9", size = 68634, upload-time = "2026-02-17T16:11:43.268Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/33/c510de7f93bf1fa19e13423a606d8189a02624a800710f6e6a0a0f0784b3/librt-0.8.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:758509ea3f1eba2a57558e7e98f4659d0ea7670bff49673b0dde18a3c7e6c0eb", size = 198941, upload-time = "2026-02-17T16:11:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/36/e725903416409a533d92398e88ce665476f275081d0d7d42f9c4951999e5/librt-0.8.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:039b9f2c506bd0ab0f8725aa5ba339c6f0cd19d3b514b50d134789809c24285d", size = 209991, upload-time = "2026-02-17T16:11:45.462Z" },
+    { url = "https://files.pythonhosted.org/packages/30/7a/8d908a152e1875c9f8eac96c97a480df425e657cdb47854b9efaa4998889/librt-0.8.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bb54f1205a3a6ab41a6fd71dfcdcbd278670d3a90ca502a30d9da583105b6f7", size = 224476, upload-time = "2026-02-17T16:11:46.542Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b8/a22c34f2c485b8903a06f3fe3315341fe6876ef3599792344669db98fcff/librt-0.8.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:05bd41cdee35b0c59c259f870f6da532a2c5ca57db95b5f23689fcb5c9e42440", size = 217518, upload-time = "2026-02-17T16:11:47.746Z" },
+    { url = "https://files.pythonhosted.org/packages/79/6f/5c6fea00357e4f82ba44f81dbfb027921f1ab10e320d4a64e1c408d035d9/librt-0.8.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adfab487facf03f0d0857b8710cf82d0704a309d8ffc33b03d9302b4c64e91a9", size = 225116, upload-time = "2026-02-17T16:11:49.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a0/95ced4e7b1267fe1e2720a111685bcddf0e781f7e9e0ce59d751c44dcfe5/librt-0.8.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:153188fe98a72f206042be10a2c6026139852805215ed9539186312d50a8e972", size = 217751, upload-time = "2026-02-17T16:11:50.49Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c2/0517281cb4d4101c27ab59472924e67f55e375bc46bedae94ac6dc6e1902/librt-0.8.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:dd3c41254ee98604b08bd5b3af5bf0a89740d4ee0711de95b65166bf44091921", size = 218378, upload-time = "2026-02-17T16:11:51.783Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e8/37b3ac108e8976888e559a7b227d0ceac03c384cfd3e7a1c2ee248dbae79/librt-0.8.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e0d138c7ae532908cbb342162b2611dbd4d90c941cd25ab82084aaf71d2c0bd0", size = 241199, upload-time = "2026-02-17T16:11:53.561Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/35812d041c53967fedf551a39399271bbe4257e681236a2cf1a69c8e7fa1/librt-0.8.1-cp312-cp312-win32.whl", hash = "sha256:43353b943613c5d9c49a25aaffdba46f888ec354e71e3529a00cca3f04d66a7a", size = 54917, upload-time = "2026-02-17T16:11:54.758Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d1/fa5d5331b862b9775aaf2a100f5ef86854e5d4407f71bddf102f4421e034/librt-0.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:ff8baf1f8d3f4b6b7257fcb75a501f2a5499d0dda57645baa09d4d0d34b19444", size = 62017, upload-time = "2026-02-17T16:11:55.748Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7c/c614252f9acda59b01a66e2ddfd243ed1c7e1deab0293332dfbccf862808/librt-0.8.1-cp312-cp312-win_arm64.whl", hash = "sha256:0f2ae3725904f7377e11cc37722d5d401e8b3d5851fb9273d7f4fe04f6b3d37d", size = 52441, upload-time = "2026-02-17T16:11:56.801Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/3c/f614c8e4eaac7cbf2bbdf9528790b21d89e277ee20d57dc6e559c626105f/librt-0.8.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7e6bad1cd94f6764e1e21950542f818a09316645337fd5ab9a7acc45d99a8f35", size = 66529, upload-time = "2026-02-17T16:11:57.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/96/5836544a45100ae411eda07d29e3d99448e5258b6e9c8059deb92945f5c2/librt-0.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cf450f498c30af55551ba4f66b9123b7185362ec8b625a773b3d39aa1a717583", size = 68669, upload-time = "2026-02-17T16:11:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/06/53/f0b992b57af6d5531bf4677d75c44f095f2366a1741fb695ee462ae04b05/librt-0.8.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:eca45e982fa074090057132e30585a7e8674e9e885d402eae85633e9f449ce6c", size = 199279, upload-time = "2026-02-17T16:11:59.862Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ad/4848cc16e268d14280d8168aee4f31cea92bbd2b79ce33d3e166f2b4e4fc/librt-0.8.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c3811485fccfda840861905b8c70bba5ec094e02825598bb9d4ca3936857a04", size = 210288, upload-time = "2026-02-17T16:12:00.954Z" },
+    { url = "https://files.pythonhosted.org/packages/52/05/27fdc2e95de26273d83b96742d8d3b7345f2ea2bdbd2405cc504644f2096/librt-0.8.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e4af413908f77294605e28cfd98063f54b2c790561383971d2f52d113d9c363", size = 224809, upload-time = "2026-02-17T16:12:02.108Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d0/78200a45ba3240cb042bc597d6f2accba9193a2c57d0356268cbbe2d0925/librt-0.8.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5212a5bd7fae98dae95710032902edcd2ec4dc994e883294f75c857b83f9aba0", size = 218075, upload-time = "2026-02-17T16:12:03.631Z" },
+    { url = "https://files.pythonhosted.org/packages/af/72/a210839fa74c90474897124c064ffca07f8d4b347b6574d309686aae7ca6/librt-0.8.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e692aa2d1d604e6ca12d35e51fdc36f4cda6345e28e36374579f7ef3611b3012", size = 225486, upload-time = "2026-02-17T16:12:04.725Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c1/a03cc63722339ddbf087485f253493e2b013039f5b707e8e6016141130fa/librt-0.8.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4be2a5c926b9770c9e08e717f05737a269b9d0ebc5d2f0060f0fe3fe9ce47acb", size = 218219, upload-time = "2026-02-17T16:12:05.828Z" },
+    { url = "https://files.pythonhosted.org/packages/58/f5/fff6108af0acf941c6f274a946aea0e484bd10cd2dc37610287ce49388c5/librt-0.8.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fd1a720332ea335ceb544cf0a03f81df92abd4bb887679fd1e460976b0e6214b", size = 218750, upload-time = "2026-02-17T16:12:07.09Z" },
+    { url = "https://files.pythonhosted.org/packages/71/67/5a387bfef30ec1e4b4f30562c8586566faf87e47d696768c19feb49e3646/librt-0.8.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2af9e01e0ef80d95ae3c720be101227edae5f2fe7e3dc63d8857fadfc5a1d", size = 241624, upload-time = "2026-02-17T16:12:08.43Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/be/24f8502db11d405232ac1162eb98069ca49c3306c1d75c6ccc61d9af8789/librt-0.8.1-cp313-cp313-win32.whl", hash = "sha256:086a32dbb71336627e78cc1d6ee305a68d038ef7d4c39aaff41ae8c9aa46e91a", size = 54969, upload-time = "2026-02-17T16:12:09.633Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/73/c9fdf6cb2a529c1a092ce769a12d88c8cca991194dfe641b6af12fa964d2/librt-0.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:e11769a1dbda4da7b00a76cfffa67aa47cfa66921d2724539eee4b9ede780b79", size = 62000, upload-time = "2026-02-17T16:12:10.632Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/97/68f80ca3ac4924f250cdfa6e20142a803e5e50fca96ef5148c52ee8c10ea/librt-0.8.1-cp313-cp313-win_arm64.whl", hash = "sha256:924817ab3141aca17893386ee13261f1d100d1ef410d70afe4389f2359fea4f0", size = 52495, upload-time = "2026-02-17T16:12:11.633Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6a/907ef6800f7bca71b525a05f1839b21f708c09043b1c6aa77b6b827b3996/librt-0.8.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6cfa7fe54fd4d1f47130017351a959fe5804bda7a0bc7e07a2cdbc3fdd28d34f", size = 66081, upload-time = "2026-02-17T16:12:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/18/25e991cd5640c9fb0f8d91b18797b29066b792f17bf8493da183bf5caabe/librt-0.8.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:228c2409c079f8c11fb2e5d7b277077f694cb93443eb760e00b3b83cb8b3176c", size = 68309, upload-time = "2026-02-17T16:12:13.756Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/36/46820d03f058cfb5a9de5940640ba03165ed8aded69e0733c417bb04df34/librt-0.8.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7aae78ab5e3206181780e56912d1b9bb9f90a7249ce12f0e8bf531d0462dd0fc", size = 196804, upload-time = "2026-02-17T16:12:14.818Z" },
+    { url = "https://files.pythonhosted.org/packages/59/18/5dd0d3b87b8ff9c061849fbdb347758d1f724b9a82241aa908e0ec54ccd0/librt-0.8.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:172d57ec04346b047ca6af181e1ea4858086c80bdf455f61994c4aa6fc3f866c", size = 206907, upload-time = "2026-02-17T16:12:16.513Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/96/ef04902aad1424fd7299b62d1890e803e6ab4018c3044dca5922319c4b97/librt-0.8.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b1977c4ea97ce5eb7755a78fae68d87e4102e4aaf54985e8b56806849cc06a3", size = 221217, upload-time = "2026-02-17T16:12:17.906Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/7e01f2dda84a8f5d280637a2e5827210a8acca9a567a54507ef1c75b342d/librt-0.8.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10c42e1f6fd06733ef65ae7bebce2872bcafd8d6e6b0a08fe0a05a23b044fb14", size = 214622, upload-time = "2026-02-17T16:12:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/8c/5b093d08a13946034fed57619742f790faf77058558b14ca36a6e331161e/librt-0.8.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4c8dfa264b9193c4ee19113c985c95f876fae5e51f731494fc4e0cf594990ba7", size = 221987, upload-time = "2026-02-17T16:12:20.331Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cc/86b0b3b151d40920ad45a94ce0171dec1aebba8a9d72bb3fa00c73ab25dd/librt-0.8.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:01170b6729a438f0dedc4a26ed342e3dc4f02d1000b4b19f980e1877f0c297e6", size = 215132, upload-time = "2026-02-17T16:12:21.54Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/be/8588164a46edf1e69858d952654e216a9a91174688eeefb9efbb38a9c799/librt-0.8.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:7b02679a0d783bdae30d443025b94465d8c3dc512f32f5b5031f93f57ac32071", size = 215195, upload-time = "2026-02-17T16:12:23.073Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f2/0b9279bea735c734d69344ecfe056c1ba211694a72df10f568745c899c76/librt-0.8.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:190b109bb69592a3401fe1ffdea41a2e73370ace2ffdc4a0e8e2b39cdea81b78", size = 237946, upload-time = "2026-02-17T16:12:24.275Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/cc/5f2a34fbc8aeb35314a3641f9956fa9051a947424652fad9882be7a97949/librt-0.8.1-cp314-cp314-win32.whl", hash = "sha256:e70a57ecf89a0f64c24e37f38d3fe217a58169d2fe6ed6d70554964042474023", size = 50689, upload-time = "2026-02-17T16:12:25.766Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/76/cd4d010ab2147339ca2b93e959c3686e964edc6de66ddacc935c325883d7/librt-0.8.1-cp314-cp314-win_amd64.whl", hash = "sha256:7e2f3edca35664499fbb36e4770650c4bd4a08abc1f4458eab9df4ec56389730", size = 57875, upload-time = "2026-02-17T16:12:27.465Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0f/2143cb3c3ca48bd3379dcd11817163ca50781927c4537345d608b5045998/librt-0.8.1-cp314-cp314-win_arm64.whl", hash = "sha256:0d2f82168e55ddefd27c01c654ce52379c0750ddc31ee86b4b266bcf4d65f2a3", size = 48058, upload-time = "2026-02-17T16:12:28.556Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0e/9b23a87e37baf00311c3efe6b48d6b6c168c29902dfc3f04c338372fd7db/librt-0.8.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2c74a2da57a094bd48d03fa5d196da83d2815678385d2978657499063709abe1", size = 68313, upload-time = "2026-02-17T16:12:29.659Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9a/859c41e5a4f1c84200a7d2b92f586aa27133c8243b6cac9926f6e54d01b9/librt-0.8.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a355d99c4c0d8e5b770313b8b247411ed40949ca44e33e46a4789b9293a907ee", size = 70994, upload-time = "2026-02-17T16:12:31.516Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/28/10605366ee599ed34223ac2bf66404c6fb59399f47108215d16d5ad751a8/librt-0.8.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2eb345e8b33fb748227409c9f1233d4df354d6e54091f0e8fc53acdb2ffedeb7", size = 220770, upload-time = "2026-02-17T16:12:33.294Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8d/16ed8fd452dafae9c48d17a6bc1ee3e818fd40ef718d149a8eff2c9f4ea2/librt-0.8.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9be2f15e53ce4e83cc08adc29b26fb5978db62ef2a366fbdf716c8a6c8901040", size = 235409, upload-time = "2026-02-17T16:12:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1b/7bdf3e49349c134b25db816e4a3db6b94a47ac69d7d46b1e682c2c4949be/librt-0.8.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:785ae29c1f5c6e7c2cde2c7c0e148147f4503da3abc5d44d482068da5322fd9e", size = 246473, upload-time = "2026-02-17T16:12:36.656Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/8a/91fab8e4fd2a24930a17188c7af5380eb27b203d72101c9cc000dbdfd95a/librt-0.8.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d3a7da44baf692f0c6aeb5b2a09c5e6fc7a703bca9ffa337ddd2e2da53f7732", size = 238866, upload-time = "2026-02-17T16:12:37.849Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e0/c45a098843fc7c07e18a7f8a24ca8496aecbf7bdcd54980c6ca1aaa79a8e/librt-0.8.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5fc48998000cbc39ec0d5311312dda93ecf92b39aaf184c5e817d5d440b29624", size = 250248, upload-time = "2026-02-17T16:12:39.445Z" },
+    { url = "https://files.pythonhosted.org/packages/82/30/07627de23036640c952cce0c1fe78972e77d7d2f8fd54fa5ef4554ff4a56/librt-0.8.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e96baa6820280077a78244b2e06e416480ed859bbd8e5d641cf5742919d8beb4", size = 240629, upload-time = "2026-02-17T16:12:40.889Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c1/55bfe1ee3542eba055616f9098eaf6eddb966efb0ca0f44eaa4aba327307/librt-0.8.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:31362dbfe297b23590530007062c32c6f6176f6099646bb2c95ab1b00a57c382", size = 239615, upload-time = "2026-02-17T16:12:42.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/39/191d3d28abc26c9099b19852e6c99f7f6d400b82fa5a4e80291bd3803e19/librt-0.8.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc3656283d11540ab0ea01978378e73e10002145117055e03722417aeab30994", size = 263001, upload-time = "2026-02-17T16:12:43.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/eb/7697f60fbe7042ab4e88f4ee6af496b7f222fffb0a4e3593ef1f29f81652/librt-0.8.1-cp314-cp314t-win32.whl", hash = "sha256:738f08021b3142c2918c03692608baed43bc51144c29e35807682f8070ee2a3a", size = 51328, upload-time = "2026-02-17T16:12:45.148Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/72/34bf2eb7a15414a23e5e70ecb9440c1d3179f393d9349338a91e2781c0fb/librt-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89815a22daf9c51884fb5dbe4f1ef65ee6a146e0b6a8df05f753e2e4a9359bf4", size = 58722, upload-time = "2026-02-17T16:12:46.85Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c8/d148e041732d631fc76036f8b30fae4e77b027a1e95b7a84bb522481a940/librt-0.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:bf512a71a23504ed08103a13c941f763db13fb11177beb3d9244c98c29fb4a61", size = 48755, upload-time = "2026-02-17T16:12:47.943Z" },
+]
+
+[[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/88/262177de60548e5a2bfc46ad28232c9e9cbde697bd94132aeb80364675cb/lxml-6.0.2.tar.gz", hash = "sha256:cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62", size = 4073426, upload-time = "2025-09-22T04:04:59.287Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/c8/8ff2bc6b920c84355146cd1ab7d181bc543b89241cfb1ebee824a7c81457/lxml-6.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a59f5448ba2ceccd06995c95ea59a7674a10de0810f2ce90c9006f3cbc044456", size = 8661887, upload-time = "2025-09-22T04:01:17.265Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/9aae1008083bb501ef63284220ce81638332f9ccbfa53765b2b7502203cf/lxml-6.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e8113639f3296706fbac34a30813929e29247718e88173ad849f57ca59754924", size = 4667818, upload-time = "2025-09-22T04:01:19.688Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ca/31fb37f99f37f1536c133476674c10b577e409c0a624384147653e38baf2/lxml-6.0.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a8bef9b9825fa8bc816a6e641bb67219489229ebc648be422af695f6e7a4fa7f", size = 4950807, upload-time = "2025-09-22T04:01:21.487Z" },
+    { url = "https://files.pythonhosted.org/packages/da/87/f6cb9442e4bada8aab5ae7e1046264f62fdbeaa6e3f6211b93f4c0dd97f1/lxml-6.0.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:65ea18d710fd14e0186c2f973dc60bb52039a275f82d3c44a0e42b43440ea534", size = 5109179, upload-time = "2025-09-22T04:01:23.32Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/20/a7760713e65888db79bbae4f6146a6ae5c04e4a204a3c48896c408cd6ed2/lxml-6.0.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c371aa98126a0d4c739ca93ceffa0fd7a5d732e3ac66a46e74339acd4d334564", size = 5023044, upload-time = "2025-09-22T04:01:25.118Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b0/7e64e0460fcb36471899f75831509098f3fd7cd02a3833ac517433cb4f8f/lxml-6.0.2-cp312-cp312-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:700efd30c0fa1a3581d80a748157397559396090a51d306ea59a70020223d16f", size = 5359685, upload-time = "2025-09-22T04:01:27.398Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e1/e5df362e9ca4e2f48ed6411bd4b3a0ae737cc842e96877f5bf9428055ab4/lxml-6.0.2-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c33e66d44fe60e72397b487ee92e01da0d09ba2d66df8eae42d77b6d06e5eba0", size = 5654127, upload-time = "2025-09-22T04:01:29.629Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d1/232b3309a02d60f11e71857778bfcd4acbdb86c07db8260caf7d008b08f8/lxml-6.0.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90a345bbeaf9d0587a3aaffb7006aa39ccb6ff0e96a57286c0cb2fd1520ea192", size = 5253958, upload-time = "2025-09-22T04:01:31.535Z" },
+    { url = "https://files.pythonhosted.org/packages/35/35/d955a070994725c4f7d80583a96cab9c107c57a125b20bb5f708fe941011/lxml-6.0.2-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:064fdadaf7a21af3ed1dcaa106b854077fbeada827c18f72aec9346847cd65d0", size = 4711541, upload-time = "2025-09-22T04:01:33.801Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/be/667d17363b38a78c4bd63cfd4b4632029fd68d2c2dc81f25ce9eb5224dd5/lxml-6.0.2-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fbc74f42c3525ac4ffa4b89cbdd00057b6196bcefe8bce794abd42d33a018092", size = 5267426, upload-time = "2025-09-22T04:01:35.639Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/62c70aa4a1c26569bc958c9ca86af2bb4e1f614e8c04fb2989833874f7ae/lxml-6.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6ddff43f702905a4e32bc24f3f2e2edfe0f8fde3277d481bffb709a4cced7a1f", size = 5064917, upload-time = "2025-09-22T04:01:37.448Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/55/6ceddaca353ebd0f1908ef712c597f8570cc9c58130dbb89903198e441fd/lxml-6.0.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:6da5185951d72e6f5352166e3da7b0dc27aa70bd1090b0eb3f7f7212b53f1bb8", size = 4788795, upload-time = "2025-09-22T04:01:39.165Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e8/fd63e15da5e3fd4c2146f8bbb3c14e94ab850589beab88e547b2dbce22e1/lxml-6.0.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:57a86e1ebb4020a38d295c04fc79603c7899e0df71588043eb218722dabc087f", size = 5676759, upload-time = "2025-09-22T04:01:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/76/47/b3ec58dc5c374697f5ba37412cd2728f427d056315d124dd4b61da381877/lxml-6.0.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2047d8234fe735ab77802ce5f2297e410ff40f5238aec569ad7c8e163d7b19a6", size = 5255666, upload-time = "2025-09-22T04:01:43.363Z" },
+    { url = "https://files.pythonhosted.org/packages/19/93/03ba725df4c3d72afd9596eef4a37a837ce8e4806010569bedfcd2cb68fd/lxml-6.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6f91fd2b2ea15a6800c8e24418c0775a1694eefc011392da73bc6cef2623b322", size = 5277989, upload-time = "2025-09-22T04:01:45.215Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/80/c06de80bfce881d0ad738576f243911fccf992687ae09fd80b734712b39c/lxml-6.0.2-cp312-cp312-win32.whl", hash = "sha256:3ae2ce7d6fedfb3414a2b6c5e20b249c4c607f72cb8d2bb7cc9c6ec7c6f4e849", size = 3611456, upload-time = "2025-09-22T04:01:48.243Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/d7/0cdfb6c3e30893463fb3d1e52bc5f5f99684a03c29a0b6b605cfae879cd5/lxml-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:72c87e5ee4e58a8354fb9c7c84cbf95a1c8236c127a5d1b7683f04bed8361e1f", size = 4011793, upload-time = "2025-09-22T04:01:50.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7b/93c73c67db235931527301ed3785f849c78991e2e34f3fd9a6663ffda4c5/lxml-6.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:61cb10eeb95570153e0c0e554f58df92ecf5109f75eacad4a95baa709e26c3d6", size = 3672836, upload-time = "2025-09-22T04:01:52.145Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/4e8f0540608977aea078bf6d79f128e0e2c2bba8af1acf775c30baa70460/lxml-6.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9b33d21594afab46f37ae58dfadd06636f154923c4e8a4d754b0127554eb2e77", size = 8648494, upload-time = "2025-09-22T04:01:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/f4/2a94a3d3dfd6c6b433501b8d470a1960a20ecce93245cf2db1706adf6c19/lxml-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6c8963287d7a4c5c9a432ff487c52e9c5618667179c18a204bdedb27310f022f", size = 4661146, upload-time = "2025-09-22T04:01:56.282Z" },
+    { url = "https://files.pythonhosted.org/packages/25/2e/4efa677fa6b322013035d38016f6ae859d06cac67437ca7dc708a6af7028/lxml-6.0.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1941354d92699fb5ffe6ed7b32f9649e43c2feb4b97205f75866f7d21aa91452", size = 4946932, upload-time = "2025-09-22T04:01:58.989Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/0f/526e78a6d38d109fdbaa5049c62e1d32fdd70c75fb61c4eadf3045d3d124/lxml-6.0.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bb2f6ca0ae2d983ded09357b84af659c954722bbf04dea98030064996d156048", size = 5100060, upload-time = "2025-09-22T04:02:00.812Z" },
+    { url = "https://files.pythonhosted.org/packages/81/76/99de58d81fa702cc0ea7edae4f4640416c2062813a00ff24bd70ac1d9c9b/lxml-6.0.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb2a12d704f180a902d7fa778c6d71f36ceb7b0d317f34cdc76a5d05aa1dd1df", size = 5019000, upload-time = "2025-09-22T04:02:02.671Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/9e57d25482bc9a9882cb0037fdb9cc18f4b79d85df94fa9d2a89562f1d25/lxml-6.0.2-cp313-cp313-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:6ec0e3f745021bfed19c456647f0298d60a24c9ff86d9d051f52b509663feeb1", size = 5348496, upload-time = "2025-09-22T04:02:04.904Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/8e/cb99bd0b83ccc3e8f0f528e9aa1f7a9965dfec08c617070c5db8d63a87ce/lxml-6.0.2-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:846ae9a12d54e368933b9759052d6206a9e8b250291109c48e350c1f1f49d916", size = 5643779, upload-time = "2025-09-22T04:02:06.689Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/34/9e591954939276bb679b73773836c6684c22e56d05980e31d52a9a8deb18/lxml-6.0.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef9266d2aa545d7374938fb5c484531ef5a2ec7f2d573e62f8ce722c735685fd", size = 5244072, upload-time = "2025-09-22T04:02:08.587Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/27/b29ff065f9aaca443ee377aff699714fcbffb371b4fce5ac4ca759e436d5/lxml-6.0.2-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:4077b7c79f31755df33b795dc12119cb557a0106bfdab0d2c2d97bd3cf3dffa6", size = 4718675, upload-time = "2025-09-22T04:02:10.783Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f756f9c2cd27caa1a6ef8c32ae47aadea697f5c2c6d07b0dae133c244fbe/lxml-6.0.2-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a7c5d5e5f1081955358533be077166ee97ed2571d6a66bdba6ec2f609a715d1a", size = 5255171, upload-time = "2025-09-22T04:02:12.631Z" },
+    { url = "https://files.pythonhosted.org/packages/61/46/bb85ea42d2cb1bd8395484fd72f38e3389611aa496ac7772da9205bbda0e/lxml-6.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8f8d0cbd0674ee89863a523e6994ac25fd5be9c8486acfc3e5ccea679bad2679", size = 5057175, upload-time = "2025-09-22T04:02:14.718Z" },
+    { url = "https://files.pythonhosted.org/packages/95/0c/443fc476dcc8e41577f0af70458c50fe299a97bb6b7505bb1ae09aa7f9ac/lxml-6.0.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:2cbcbf6d6e924c28f04a43f3b6f6e272312a090f269eff68a2982e13e5d57659", size = 4785688, upload-time = "2025-09-22T04:02:16.957Z" },
+    { url = "https://files.pythonhosted.org/packages/48/78/6ef0b359d45bb9697bc5a626e1992fa5d27aa3f8004b137b2314793b50a0/lxml-6.0.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:dfb874cfa53340009af6bdd7e54ebc0d21012a60a4e65d927c2e477112e63484", size = 5660655, upload-time = "2025-09-22T04:02:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/ea/e1d33808f386bc1339d08c0dcada6e4712d4ed8e93fcad5f057070b7988a/lxml-6.0.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fb8dae0b6b8b7f9e96c26fdd8121522ce5de9bb5538010870bd538683d30e9a2", size = 5247695, upload-time = "2025-09-22T04:02:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/47/eba75dfd8183673725255247a603b4ad606f4ae657b60c6c145b381697da/lxml-6.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:358d9adae670b63e95bc59747c72f4dc97c9ec58881d4627fe0120da0f90d314", size = 5269841, upload-time = "2025-09-22T04:02:22.489Z" },
+    { url = "https://files.pythonhosted.org/packages/76/04/5c5e2b8577bc936e219becb2e98cdb1aca14a4921a12995b9d0c523502ae/lxml-6.0.2-cp313-cp313-win32.whl", hash = "sha256:e8cd2415f372e7e5a789d743d133ae474290a90b9023197fd78f32e2dc6873e2", size = 3610700, upload-time = "2025-09-22T04:02:24.465Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/0a/4643ccc6bb8b143e9f9640aa54e38255f9d3b45feb2cbe7ae2ca47e8782e/lxml-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:b30d46379644fbfc3ab81f8f82ae4de55179414651f110a1514f0b1f8f6cb2d7", size = 4010347, upload-time = "2025-09-22T04:02:26.286Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ef/dcf1d29c3f530577f61e5fe2f1bd72929acf779953668a8a47a479ae6f26/lxml-6.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:13dcecc9946dca97b11b7c40d29fba63b55ab4170d3c0cf8c0c164343b9bfdcf", size = 3671248, upload-time = "2025-09-22T04:02:27.918Z" },
+    { url = "https://files.pythonhosted.org/packages/03/15/d4a377b385ab693ce97b472fe0c77c2b16ec79590e688b3ccc71fba19884/lxml-6.0.2-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:b0c732aa23de8f8aec23f4b580d1e52905ef468afb4abeafd3fec77042abb6fe", size = 8659801, upload-time = "2025-09-22T04:02:30.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e8/c128e37589463668794d503afaeb003987373c5f94d667124ffd8078bbd9/lxml-6.0.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4468e3b83e10e0317a89a33d28f7aeba1caa4d1a6fd457d115dd4ffe90c5931d", size = 4659403, upload-time = "2025-09-22T04:02:32.119Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ce/74903904339decdf7da7847bb5741fc98a5451b42fc419a86c0c13d26fe2/lxml-6.0.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:abd44571493973bad4598a3be7e1d807ed45aa2adaf7ab92ab7c62609569b17d", size = 4966974, upload-time = "2025-09-22T04:02:34.155Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d3/131dec79ce61c5567fecf82515bd9bc36395df42501b50f7f7f3bd065df0/lxml-6.0.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:370cd78d5855cfbffd57c422851f7d3864e6ae72d0da615fca4dad8c45d375a5", size = 5102953, upload-time = "2025-09-22T04:02:36.054Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ea/a43ba9bb750d4ffdd885f2cd333572f5bb900cd2408b67fdda07e85978a0/lxml-6.0.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:901e3b4219fa04ef766885fb40fa516a71662a4c61b80c94d25336b4934b71c0", size = 5055054, upload-time = "2025-09-22T04:02:38.154Z" },
+    { url = "https://files.pythonhosted.org/packages/60/23/6885b451636ae286c34628f70a7ed1fcc759f8d9ad382d132e1c8d3d9bfd/lxml-6.0.2-cp314-cp314-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:a4bf42d2e4cf52c28cc1812d62426b9503cdb0c87a6de81442626aa7d69707ba", size = 5352421, upload-time = "2025-09-22T04:02:40.413Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5b/fc2ddfc94ddbe3eebb8e9af6e3fd65e2feba4967f6a4e9683875c394c2d8/lxml-6.0.2-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2c7fdaa4d7c3d886a42534adec7cfac73860b89b4e5298752f60aa5984641a0", size = 5673684, upload-time = "2025-09-22T04:02:42.288Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/47293c58cc91769130fbf85531280e8cc7868f7fbb6d92f4670071b9cb3e/lxml-6.0.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98a5e1660dc7de2200b00d53fa00bcd3c35a3608c305d45a7bbcaf29fa16e83d", size = 5252463, upload-time = "2025-09-22T04:02:44.165Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/da/ba6eceb830c762b48e711ded880d7e3e89fc6c7323e587c36540b6b23c6b/lxml-6.0.2-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:dc051506c30b609238d79eda75ee9cab3e520570ec8219844a72a46020901e37", size = 4698437, upload-time = "2025-09-22T04:02:46.524Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/24/7be3f82cb7990b89118d944b619e53c656c97dc89c28cfb143fdb7cd6f4d/lxml-6.0.2-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8799481bbdd212470d17513a54d568f44416db01250f49449647b5ab5b5dccb9", size = 5269890, upload-time = "2025-09-22T04:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/dcfb9ea1e16c665efd7538fc5d5c34071276ce9220e234217682e7d2c4a5/lxml-6.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9261bb77c2dab42f3ecd9103951aeca2c40277701eb7e912c545c1b16e0e4917", size = 5097185, upload-time = "2025-09-22T04:02:50.746Z" },
+    { url = "https://files.pythonhosted.org/packages/21/04/a60b0ff9314736316f28316b694bccbbabe100f8483ad83852d77fc7468e/lxml-6.0.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:65ac4a01aba353cfa6d5725b95d7aed6356ddc0a3cd734de00124d285b04b64f", size = 4745895, upload-time = "2025-09-22T04:02:52.968Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/bd/7d54bd1846e5a310d9c715921c5faa71cf5c0853372adf78aee70c8d7aa2/lxml-6.0.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:b22a07cbb82fea98f8a2fd814f3d1811ff9ed76d0fc6abc84eb21527596e7cc8", size = 5695246, upload-time = "2025-09-22T04:02:54.798Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/5643d6ab947bc371da21323acb2a6e603cedbe71cb4c99c8254289ab6f4e/lxml-6.0.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:d759cdd7f3e055d6bc8d9bec3ad905227b2e4c785dc16c372eb5b5e83123f48a", size = 5260797, upload-time = "2025-09-22T04:02:57.058Z" },
+    { url = "https://files.pythonhosted.org/packages/33/da/34c1ec4cff1eea7d0b4cd44af8411806ed943141804ac9c5d565302afb78/lxml-6.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:945da35a48d193d27c188037a05fec5492937f66fb1958c24fc761fb9d40d43c", size = 5277404, upload-time = "2025-09-22T04:02:58.966Z" },
+    { url = "https://files.pythonhosted.org/packages/82/57/4eca3e31e54dc89e2c3507e1cd411074a17565fa5ffc437c4ae0a00d439e/lxml-6.0.2-cp314-cp314-win32.whl", hash = "sha256:be3aaa60da67e6153eb15715cc2e19091af5dc75faef8b8a585aea372507384b", size = 3670072, upload-time = "2025-09-22T04:03:38.05Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/e0/c96cf13eccd20c9421ba910304dae0f619724dcf1702864fd59dd386404d/lxml-6.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:fa25afbadead523f7001caf0c2382afd272c315a033a7b06336da2637d92d6ed", size = 4080617, upload-time = "2025-09-22T04:03:39.835Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5d/b3f03e22b3d38d6f188ef044900a9b29b2fe0aebb94625ce9fe244011d34/lxml-6.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:063eccf89df5b24e361b123e257e437f9e9878f425ee9aae3144c77faf6da6d8", size = 3754930, upload-time = "2025-09-22T04:03:41.565Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/5c/42c2c4c03554580708fc738d13414801f340c04c3eff90d8d2d227145275/lxml-6.0.2-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:6162a86d86893d63084faaf4ff937b3daea233e3682fb4474db07395794fa80d", size = 8910380, upload-time = "2025-09-22T04:03:01.645Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/4f/12df843e3e10d18d468a7557058f8d3733e8b6e12401f30b1ef29360740f/lxml-6.0.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:414aaa94e974e23a3e92e7ca5b97d10c0cf37b6481f50911032c69eeb3991bba", size = 4775632, upload-time = "2025-09-22T04:03:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0c/9dc31e6c2d0d418483cbcb469d1f5a582a1cd00a1f4081953d44051f3c50/lxml-6.0.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48461bd21625458dd01e14e2c38dd0aea69addc3c4f960c30d9f59d7f93be601", size = 4975171, upload-time = "2025-09-22T04:03:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2b/9b870c6ca24c841bdd887504808f0417aa9d8d564114689266f19ddf29c8/lxml-6.0.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25fcc59afc57d527cfc78a58f40ab4c9b8fd096a9a3f964d2781ffb6eb33f4ed", size = 5110109, upload-time = "2025-09-22T04:03:07.452Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/0c/4f5f2a4dd319a178912751564471355d9019e220c20d7db3fb8307ed8582/lxml-6.0.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5179c60288204e6ddde3f774a93350177e08876eaf3ab78aa3a3649d43eb7d37", size = 5041061, upload-time = "2025-09-22T04:03:09.297Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/554eed290365267671fe001a20d72d14f468ae4e6acef1e179b039436967/lxml-6.0.2-cp314-cp314t-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:967aab75434de148ec80597b75062d8123cadf2943fb4281f385141e18b21338", size = 5306233, upload-time = "2025-09-22T04:03:11.651Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/31/1d748aa275e71802ad9722df32a7a35034246b42c0ecdd8235412c3396ef/lxml-6.0.2-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d100fcc8930d697c6561156c6810ab4a508fb264c8b6779e6e61e2ed5e7558f9", size = 5604739, upload-time = "2025-09-22T04:03:13.592Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/41/2c11916bcac09ed561adccacceaedd2bf0e0b25b297ea92aab99fd03d0fa/lxml-6.0.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ca59e7e13e5981175b8b3e4ab84d7da57993eeff53c07764dcebda0d0e64ecd", size = 5225119, upload-time = "2025-09-22T04:03:15.408Z" },
+    { url = "https://files.pythonhosted.org/packages/99/05/4e5c2873d8f17aa018e6afde417c80cc5d0c33be4854cce3ef5670c49367/lxml-6.0.2-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:957448ac63a42e2e49531b9d6c0fa449a1970dbc32467aaad46f11545be9af1d", size = 4633665, upload-time = "2025-09-22T04:03:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c9/dcc2da1bebd6275cdc723b515f93edf548b82f36a5458cca3578bc899332/lxml-6.0.2-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b7fc49c37f1786284b12af63152fe1d0990722497e2d5817acfe7a877522f9a9", size = 5234997, upload-time = "2025-09-22T04:03:19.14Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e2/5172e4e7468afca64a37b81dba152fc5d90e30f9c83c7c3213d6a02a5ce4/lxml-6.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e19e0643cc936a22e837f79d01a550678da8377d7d801a14487c10c34ee49c7e", size = 5090957, upload-time = "2025-09-22T04:03:21.436Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b3/15461fd3e5cd4ddcb7938b87fc20b14ab113b92312fc97afe65cd7c85de1/lxml-6.0.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:1db01e5cf14345628e0cbe71067204db658e2fb8e51e7f33631f5f4735fefd8d", size = 4764372, upload-time = "2025-09-22T04:03:23.27Z" },
+    { url = "https://files.pythonhosted.org/packages/05/33/f310b987c8bf9e61c4dd8e8035c416bd3230098f5e3cfa69fc4232de7059/lxml-6.0.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:875c6b5ab39ad5291588aed6925fac99d0097af0dd62f33c7b43736043d4a2ec", size = 5634653, upload-time = "2025-09-22T04:03:25.767Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/51c80e75e0bc9382158133bdcf4e339b5886c6ee2418b5199b3f1a61ed6d/lxml-6.0.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:cdcbed9ad19da81c480dfd6dd161886db6096083c9938ead313d94b30aadf272", size = 5233795, upload-time = "2025-09-22T04:03:27.62Z" },
+    { url = "https://files.pythonhosted.org/packages/56/4d/4856e897df0d588789dd844dbed9d91782c4ef0b327f96ce53c807e13128/lxml-6.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:80dadc234ebc532e09be1975ff538d154a7fa61ea5031c03d25178855544728f", size = 5257023, upload-time = "2025-09-22T04:03:30.056Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/85/86766dfebfa87bea0ab78e9ff7a4b4b45225df4b4d3b8cc3c03c5cd68464/lxml-6.0.2-cp314-cp314t-win32.whl", hash = "sha256:da08e7bb297b04e893d91087df19638dc7a6bb858a954b0cc2b9f5053c922312", size = 3911420, upload-time = "2025-09-22T04:03:32.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1a/b248b355834c8e32614650b8008c69ffeb0ceb149c793961dd8c0b991bb3/lxml-6.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:252a22982dca42f6155125ac76d3432e548a7625d56f5a273ee78a5057216eca", size = 4406837, upload-time = "2025-09-22T04:03:34.027Z" },
+    { url = "https://files.pythonhosted.org/packages/92/aa/df863bcc39c5e0946263454aba394de8a9084dbaff8ad143846b0d844739/lxml-6.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:bb4c1847b303835d89d785a18801a883436cdfd5dc3d62947f9c49e24f0f5a2c", size = 3822205, upload-time = "2025-09-22T04:03:36.249Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "1.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/b0089fe7fef0a994ae5ee07029ced0526082c6cfaaa4c10d40a10e33b097/mypy-1.20.0.tar.gz", hash = "sha256:eb96c84efcc33f0b5e0e04beacf00129dd963b67226b01c00b9dfc8affb464c3", size = 3815028, upload-time = "2026-03-31T16:55:14.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/dd/3afa29b58c2e57c79116ed55d700721c3c3b15955e2b6251dd165d377c0e/mypy-1.20.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:002b613ae19f4ac7d18b7e168ffe1cb9013b37c57f7411984abbd3b817b0a214", size = 14509525, upload-time = "2026-03-31T16:55:01.824Z" },
+    { url = "https://files.pythonhosted.org/packages/54/eb/227b516ab8cad9f2a13c5e7a98d28cd6aa75e9c83e82776ae6c1c4c046c7/mypy-1.20.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a9336b5e6712f4adaf5afc3203a99a40b379049104349d747eb3e5a3aa23ac2e", size = 13326469, upload-time = "2026-03-31T16:51:41.23Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d4/1ddb799860c1b5ac6117ec307b965f65deeb47044395ff01ab793248a591/mypy-1.20.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f13b3e41bce9d257eded794c0f12878af3129d80aacd8a3ee0dee51f3a978651", size = 13705953, upload-time = "2026-03-31T16:48:55.69Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b7/54a720f565a87b893182a2a393370289ae7149e4715859e10e1c05e49154/mypy-1.20.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9804c3ad27f78e54e58b32e7cb532d128b43dbfb9f3f9f06262b821a0f6bd3f5", size = 14710363, upload-time = "2026-03-31T16:53:26.948Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2a/74810274848d061f8a8ea4ac23aaad43bd3d8c1882457999c2e568341c57/mypy-1.20.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:697f102c5c1d526bdd761a69f17c6070f9892eebcb94b1a5963d679288c09e78", size = 14947005, upload-time = "2026-03-31T16:50:17.591Z" },
+    { url = "https://files.pythonhosted.org/packages/77/91/21b8ba75f958bcda75690951ce6fa6b7138b03471618959529d74b8544e2/mypy-1.20.0-cp312-cp312-win_amd64.whl", hash = "sha256:0ecd63f75fdd30327e4ad8b5704bd6d91fc6c1b2e029f8ee14705e1207212489", size = 10880616, upload-time = "2026-03-31T16:52:19.986Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/15/3d8198ef97c1ca03aea010cce4f1d4f3bc5d9849e8c0140111ca2ead9fdd/mypy-1.20.0-cp312-cp312-win_arm64.whl", hash = "sha256:f194db59657c58593a3c47c6dfd7bad4ef4ac12dbc94d01b3a95521f78177e33", size = 9813091, upload-time = "2026-03-31T16:53:44.385Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a7/f64ea7bd592fa431cb597418b6dec4a47f7d0c36325fec7ac67bc8402b94/mypy-1.20.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b20c8b0fd5877abdf402e79a3af987053de07e6fb208c18df6659f708b535134", size = 14485344, upload-time = "2026-03-31T16:49:16.78Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/72/8927d84cfc90c6abea6e96663576e2e417589347eb538749a464c4c218a0/mypy-1.20.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:367e5c993ba34d5054d11937d0485ad6dfc60ba760fa326c01090fc256adf15c", size = 13327400, upload-time = "2026-03-31T16:53:08.02Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/4a/11ab99f9afa41aa350178d24a7d2da17043228ea10f6456523f64b5a6cf6/mypy-1.20.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f799d9db89fc00446f03281f84a221e50018fc40113a3ba9864b132895619ebe", size = 13706384, upload-time = "2026-03-31T16:52:28.577Z" },
+    { url = "https://files.pythonhosted.org/packages/42/79/694ca73979cfb3535ebfe78733844cd5aff2e63304f59bf90585110d975a/mypy-1.20.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:555658c611099455b2da507582ea20d2043dfdfe7f5ad0add472b1c6238b433f", size = 14700378, upload-time = "2026-03-31T16:48:45.527Z" },
+    { url = "https://files.pythonhosted.org/packages/84/24/a022ccab3a46e3d2cdf2e0e260648633640eb396c7e75d5a42818a8d3971/mypy-1.20.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:efe8d70949c3023698c3fca1e94527e7e790a361ab8116f90d11221421cd8726", size = 14932170, upload-time = "2026-03-31T16:49:36.038Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/9b/549228d88f574d04117e736f55958bd4908f980f9f5700a07aeb85df005b/mypy-1.20.0-cp313-cp313-win_amd64.whl", hash = "sha256:f49590891d2c2f8a9de15614e32e459a794bcba84693c2394291a2038bbaaa69", size = 10888526, upload-time = "2026-03-31T16:50:59.827Z" },
+    { url = "https://files.pythonhosted.org/packages/91/17/15095c0e54a8bc04d22d4ff06b2139d5f142c2e87520b4e39010c4862771/mypy-1.20.0-cp313-cp313-win_arm64.whl", hash = "sha256:76a70bf840495729be47510856b978f1b0ec7d08f257ca38c9d932720bf6b43e", size = 9816456, upload-time = "2026-03-31T16:49:59.537Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/0e/6ca4a84cbed9e62384bc0b2974c90395ece5ed672393e553996501625fc5/mypy-1.20.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0f42dfaab7ec1baff3b383ad7af562ab0de573c5f6edb44b2dab016082b89948", size = 14483331, upload-time = "2026-03-31T16:52:57.999Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/c5/5fe9d8a729dd9605064691816243ae6c49fde0bd28f6e5e17f6a24203c43/mypy-1.20.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:31b5dbb55293c1bd27c0fc813a0d2bb5ceef9d65ac5afa2e58f829dab7921fd5", size = 13342047, upload-time = "2026-03-31T16:54:21.555Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/33/e18bcfa338ca4e6b2771c85d4c5203e627d0c69d9de5c1a2cf2ba13320ba/mypy-1.20.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49d11c6f573a5a08f77fad13faff2139f6d0730ebed2cfa9b3d2702671dd7188", size = 13719585, upload-time = "2026-03-31T16:51:53.89Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8d/93491ff7b79419edc7eabf95cb3b3f7490e2e574b2855c7c7e7394ff933f/mypy-1.20.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d3243c406773185144527f83be0e0aefc7bf4601b0b2b956665608bf7c98a83", size = 14685075, upload-time = "2026-03-31T16:54:04.464Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9d/d924b38a4923f8d164bf2b4ec98bf13beaf6e10a5348b4b137eadae40a6e/mypy-1.20.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a79c1eba7ac4209f2d850f0edd0a2f8bba88cbfdfefe6fb76a19e9d4fe5e71a2", size = 14919141, upload-time = "2026-03-31T16:54:51.785Z" },
+    { url = "https://files.pythonhosted.org/packages/59/98/1da9977016678c0b99d43afe52ed00bb3c1a0c4c995d3e6acca1a6ebb9b4/mypy-1.20.0-cp314-cp314-win_amd64.whl", hash = "sha256:00e047c74d3ec6e71a2eb88e9ea551a2edb90c21f993aefa9e0d2a898e0bb732", size = 11050925, upload-time = "2026-03-31T16:51:30.758Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e3/ba0b7a3143e49a9c4f5967dde6ea4bf8e0b10ecbbcca69af84027160ee89/mypy-1.20.0-cp314-cp314-win_arm64.whl", hash = "sha256:931a7630bba591593dcf6e97224a21ff80fb357e7982628d25e3c618e7f598ef", size = 10001089, upload-time = "2026-03-31T16:49:43.632Z" },
+    { url = "https://files.pythonhosted.org/packages/12/28/e617e67b3be9d213cda7277913269c874eb26472489f95d09d89765ce2d8/mypy-1.20.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:26c8b52627b6552f47ff11adb4e1509605f094e29815323e487fc0053ebe93d1", size = 15534710, upload-time = "2026-03-31T16:52:12.506Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0c/3b5f2d3e45dc7169b811adce8451679d9430399d03b168f9b0489f43adaa/mypy-1.20.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:39362cdb4ba5f916e7976fccecaab1ba3a83e35f60fa68b64e9a70e221bb2436", size = 14393013, upload-time = "2026-03-31T16:54:41.186Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/49/edc8b0aa145cc09c1c74f7ce2858eead9329931dcbbb26e2ad40906daa4e/mypy-1.20.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34506397dbf40c15dc567635d18a21d33827e9ab29014fb83d292a8f4f8953b6", size = 15047240, upload-time = "2026-03-31T16:54:31.955Z" },
+    { url = "https://files.pythonhosted.org/packages/42/37/a946bb416e37a57fa752b3100fd5ede0e28df94f92366d1716555d47c454/mypy-1.20.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:555493c44a4f5a1b58d611a43333e71a9981c6dbe26270377b6f8174126a0526", size = 15858565, upload-time = "2026-03-31T16:53:36.997Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/99/7690b5b5b552db1bd4ff362e4c0eb3107b98d680835e65823fbe888c8b78/mypy-1.20.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2721f0ce49cb74a38f00c50da67cb7d36317b5eda38877a49614dc018e91c787", size = 16087874, upload-time = "2026-03-31T16:52:48.313Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/76/53e893a498138066acd28192b77495c9357e5a58cc4be753182846b43315/mypy-1.20.0-cp314-cp314t-win_amd64.whl", hash = "sha256:47781555a7aa5fedcc2d16bcd72e0dc83eb272c10dd657f9fb3f9cc08e2e6abb", size = 12572380, upload-time = "2026-03-31T16:49:52.454Z" },
+    { url = "https://files.pythonhosted.org/packages/76/9c/6dbdae21f01b7aacddc2c0bbf3c5557aa547827fdf271770fe1e521e7093/mypy-1.20.0-cp314-cp314t-win_arm64.whl", hash = "sha256:c70380fe5d64010f79fb863b9081c7004dd65225d2277333c219d93a10dad4dd", size = 10381174, upload-time = "2026-03-31T16:51:20.179Z" },
+    { url = "https://files.pythonhosted.org/packages/21/66/4d734961ce167f0fd8380769b3b7c06dbdd6ff54c2190f3f2ecd22528158/mypy-1.20.0-py3-none-any.whl", hash = "sha256:a6e0641147cbfa7e4e94efdb95c2dab1aff8cfc159ded13e07f308ddccc8c48e", size = 2636365, upload-time = "2026-03-31T16:51:44.911Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/97/e9f1ca355108ef7194e38c812ef40ba98c7208f47b13ad78d023caa583da/ruff-0.15.9.tar.gz", hash = "sha256:29cbb1255a9797903f6dde5ba0188c707907ff44a9006eb273b5a17bfa0739a2", size = 4617361, upload-time = "2026-04-02T18:17:20.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/1f/9cdfd0ac4b9d1e5a6cf09bedabdf0b56306ab5e333c85c87281273e7b041/ruff-0.15.9-py3-none-linux_armv6l.whl", hash = "sha256:6efbe303983441c51975c243e26dff328aca11f94b70992f35b093c2e71801e1", size = 10511206, upload-time = "2026-04-02T18:16:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/f6/32bfe3e9c136b35f02e489778d94384118bb80fd92c6d92e7ccd97db12ce/ruff-0.15.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4965bac6ac9ea86772f4e23587746f0b7a395eccabb823eb8bfacc3fa06069f7", size = 10923307, upload-time = "2026-04-02T18:17:08.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/25/de55f52ab5535d12e7aaba1de37a84be6179fb20bddcbe71ec091b4a3243/ruff-0.15.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:eaf05aad70ca5b5a0a4b0e080df3a6b699803916d88f006efd1f5b46302daab8", size = 10316722, upload-time = "2026-04-02T18:16:44.206Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/690d75f3fd6278fe55fff7c9eb429c92d207e14b25d1cae4064a32677029/ruff-0.15.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9439a342adb8725f32f92732e2bafb6d5246bd7a5021101166b223d312e8fc59", size = 10623674, upload-time = "2026-04-02T18:16:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/ec/176f6987be248fc5404199255522f57af1b4a5a1b57727e942479fec98ad/ruff-0.15.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9c5e6faf9d97c8edc43877c3f406f47446fc48c40e1442d58cfcdaba2acea745", size = 10351516, upload-time = "2026-04-02T18:16:57.206Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/fc/51cffbd2b3f240accc380171d51446a32aa2ea43a40d4a45ada67368fbd2/ruff-0.15.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b34a9766aeec27a222373d0b055722900fbc0582b24f39661aa96f3fe6ad901", size = 11150202, upload-time = "2026-04-02T18:17:06.452Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d4/25292a6dfc125f6b6528fe6af31f5e996e19bf73ca8e3ce6eb7fa5b95885/ruff-0.15.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:89dd695bc72ae76ff484ae54b7e8b0f6b50f49046e198355e44ea656e521fef9", size = 11988891, upload-time = "2026-04-02T18:17:18.575Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e1/1eebcb885c10e19f969dcb93d8413dfee8172578709d7ee933640f5e7147/ruff-0.15.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ce187224ef1de1bd225bc9a152ac7102a6171107f026e81f317e4257052916d5", size = 11480576, upload-time = "2026-04-02T18:16:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6b/a1548ac378a78332a4c3dcf4a134c2475a36d2a22ddfa272acd574140b50/ruff-0.15.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b0c7c341f68adb01c488c3b7d4b49aa8ea97409eae6462d860a79cf55f431b6", size = 11254525, upload-time = "2026-04-02T18:17:02.041Z" },
+    { url = "https://files.pythonhosted.org/packages/42/aa/4bb3af8e61acd9b1281db2ab77e8b2c3c5e5599bf2a29d4a942f1c62b8d6/ruff-0.15.9-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:55cc15eee27dc0eebdfcb0d185a6153420efbedc15eb1d38fe5e685657b0f840", size = 11204072, upload-time = "2026-04-02T18:17:13.581Z" },
+    { url = "https://files.pythonhosted.org/packages/69/48/d550dc2aa6e423ea0bcc1d0ff0699325ffe8a811e2dba156bd80750b86dc/ruff-0.15.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6537f6eed5cda688c81073d46ffdfb962a5f29ecb6f7e770b2dc920598997ed", size = 10594998, upload-time = "2026-04-02T18:16:46.369Z" },
+    { url = "https://files.pythonhosted.org/packages/63/47/321167e17f5344ed5ec6b0aa2cff64efef5f9e985af8f5622cfa6536043f/ruff-0.15.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6d3fcbca7388b066139c523bda744c822258ebdcfbba7d24410c3f454cc9af71", size = 10359769, upload-time = "2026-04-02T18:17:10.994Z" },
+    { url = "https://files.pythonhosted.org/packages/67/5e/074f00b9785d1d2c6f8c22a21e023d0c2c1817838cfca4c8243200a1fa87/ruff-0.15.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:058d8e99e1bfe79d8a0def0b481c56059ee6716214f7e425d8e737e412d69677", size = 10850236, upload-time = "2026-04-02T18:16:48.749Z" },
+    { url = "https://files.pythonhosted.org/packages/76/37/804c4135a2a2caf042925d30d5f68181bdbd4461fd0d7739da28305df593/ruff-0.15.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8e1ddb11dbd61d5983fa2d7d6370ef3eb210951e443cace19594c01c72abab4c", size = 11358343, upload-time = "2026-04-02T18:16:55.068Z" },
+    { url = "https://files.pythonhosted.org/packages/88/3d/1364fcde8656962782aa9ea93c92d98682b1ecec2f184e625a965ad3b4a6/ruff-0.15.9-py3-none-win32.whl", hash = "sha256:bde6ff36eaf72b700f32b7196088970bf8fdb2b917b7accd8c371bfc0fd573ec", size = 10583382, upload-time = "2026-04-02T18:17:04.261Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/56/5c7084299bd2cacaa07ae63a91c6f4ba66edc08bf28f356b24f6b717c799/ruff-0.15.9-py3-none-win_amd64.whl", hash = "sha256:45a70921b80e1c10cf0b734ef09421f71b5aa11d27404edc89d7e8a69505e43d", size = 11744969, upload-time = "2026-04-02T18:16:59.611Z" },
+    { url = "https://files.pythonhosted.org/packages/03/36/76704c4f312257d6dbaae3c959add2a622f63fcca9d864659ce6d8d97d3d/ruff-0.15.9-py3-none-win_arm64.whl", hash = "sha256:0694e601c028fd97dc5c6ee244675bc241aeefced7ef80cd9c6935a871078f53", size = 11005870, upload-time = "2026-04-02T18:17:15.773Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+]
+
+[[package]]
+name = "textual"
+version = "8.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/07/766ad19cf2b15cae2d79e0db46a1b783b62316e9ff3e058e7424b2a4398b/textual-8.2.1.tar.gz", hash = "sha256:4176890e9cd5c95dcdd206541b2956b0808e74c8c36381c88db53dcb45237451", size = 1848386, upload-time = "2026-03-29T03:57:32.242Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/09/c6f000c2e3702036e593803319af02feee58a662528d0d5728a37e1cf81b/textual-8.2.1-py3-none-any.whl", hash = "sha256:746cbf947a8ca875afc09779ef38cadbc7b9f15ac886a5090f7099fef5ade990", size = 723871, upload-time = "2026-03-29T03:57:34.334Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]


### PR DESCRIPTION
## Summary
- port the existing POC from https://github.com/CraftBrewzMusic/AirTable_CBz into this repo under the `atp` package and CLI
- keep the Textual TUI and schema-driven Airtable model while moving committed docs under `DOCS/AIRTABLE_API`
- promote Chevy/PBGL workflows into `atp chevy ...` commands and add setup/update/releasing docs
- make mutating record commands preview by default and require `--apply` for live Airtable writes

## Verification
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q`
- `UV_CACHE_DIR=/tmp/uv-cache uv run atp --help`
- `UV_CACHE_DIR=/tmp/uv-cache uv run atp records create Artists --field "Name=Example"`
- `UV_CACHE_DIR=/tmp/uv-cache uv run atp records create Artists --field "Name=Example" --apply`
- `UV_CACHE_DIR=/tmp/uv-cache uv run atp schema redoc /path/to/airtable-export.html`

## Next Steps
- exercise the TUI against a real PBGL Airtable token and confirm the preview/apply behavior feels right for operators
- decide whether the copied `scripts/` directory should remain as migration reference material or be removed now that the packaged `atp chevy` commands exist
- cut the first tagged release after validating setup/update flows from a fresh clone
